### PR TITLE
Add minimal Rust PQC client/server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "nuntium"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+pqcrypto-kyber = "0.7"
+pqcrypto-traits = "0.3"
+aes-gcm = { version = "0.10", features = ["aes"] }
+rand = "0.8"
+sha2 = "0.10"
+tun = "0.6"

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -1,0 +1,46 @@
+use pqcrypto_traits::kem::PublicKey as _;
+use std::net::TcpStream;
+use std::io::{Read, Write};
+use nuntium::{pqc, crypto::Aes256GcmHelper, ipv6::make_ipv6_from_pubkey};
+
+fn main() -> std::io::Result<()> {
+    let (pk, _sk) = pqc::generate_keypair();
+    let addr = make_ipv6_from_pubkey(pk.as_bytes());
+    println!("Client IPv6: {}", addr);
+
+    let mut stream = TcpStream::connect("127.0.0.1:9000")?;
+
+    // send client pk
+    stream.write_all(pk.as_bytes())?;
+
+    // receive server pk
+    let mut server_pk_bytes = vec![0u8; pqc::PUBLIC_KEY_LEN];
+    stream.read_exact(&mut server_pk_bytes)?;
+    let server_pk = pqc::public_key_from_bytes(&server_pk_bytes);
+
+    // encapsulate
+    let (ct, shared) = pqc::encapsulate(&server_pk);
+    stream.write_all(&ct)?;
+    println!("Client shared secret established");
+    let mut aes = Aes256GcmHelper::new(&shared);
+
+    // send encrypted packet
+    let msg = b"ping";
+    let (ct_out, nonce_out) = aes.encrypt(msg);
+    stream.write_all(&nonce_out)?;
+    stream.write_all(&(ct_out.len() as u16).to_be_bytes())?;
+    stream.write_all(&ct_out)?;
+
+    // receive response
+    let mut nonce = [0u8; 12];
+    stream.read_exact(&mut nonce)?;
+    let mut len_buf = [0u8; 2];
+    stream.read_exact(&mut len_buf)?;
+    let len = u16::from_be_bytes(len_buf) as usize;
+    let mut enc = vec![0u8; len];
+    stream.read_exact(&mut enc)?;
+    let plain = aes.decrypt(&nonce, &enc).expect("decrypt");
+    println!("Client received: {}", String::from_utf8_lossy(&plain));
+
+    Ok(())
+}

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,0 +1,51 @@
+use pqcrypto_traits::kem::PublicKey as _;
+use std::net::{TcpListener};
+use std::io::{Read, Write};
+use nuntium::{pqc, crypto::Aes256GcmHelper, ipv6::make_ipv6_from_pubkey};
+
+fn main() -> std::io::Result<()> {
+    let (pk, sk) = pqc::generate_keypair();
+    let addr = make_ipv6_from_pubkey(pk.as_bytes());
+    println!("Server IPv6: {}", addr);
+
+    let listener = TcpListener::bind("0.0.0.0:9000")?;
+    let (mut stream, _) = listener.accept()?;
+
+    // receive client pk
+    let mut client_pk_bytes = vec![0u8; pqc::PUBLIC_KEY_LEN];
+    stream.read_exact(&mut client_pk_bytes)?;
+    let client_pk = pqc::public_key_from_bytes(&client_pk_bytes);
+    let _client_addr = make_ipv6_from_pubkey(client_pk.as_bytes());
+    println!("Client IPv6: {}", _client_addr);
+
+    // send server pk
+    stream.write_all(pk.as_bytes())?;
+
+    // receive ciphertext from client
+    let mut ct = vec![0u8; pqc::CIPHERTEXT_LEN];
+    stream.read_exact(&mut ct)?;
+
+    let shared = pqc::decapsulate(&ct, &sk);
+    println!("Server shared secret established");
+    let mut aes = Aes256GcmHelper::new(&shared);
+
+    // receive encrypted packet
+    let mut nonce = [0u8; 12];
+    stream.read_exact(&mut nonce)?;
+    let mut len_buf = [0u8; 2];
+    stream.read_exact(&mut len_buf)?;
+    let len = u16::from_be_bytes(len_buf) as usize;
+    let mut enc = vec![0u8; len];
+    stream.read_exact(&mut enc)?;
+    let plain = aes.decrypt(&nonce, &enc).expect("decrypt");
+    println!("Server received: {}", String::from_utf8_lossy(&plain));
+
+    // reply
+    let reply = b"pong";
+    let (ct_out, nonce_out) = aes.encrypt(reply);
+    stream.write_all(&nonce_out)?;
+    stream.write_all(&(ct_out.len() as u16).to_be_bytes())?;
+    stream.write_all(&ct_out)?;
+
+    Ok(())
+}

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,32 @@
+use aes_gcm::{Aes256Gcm, Key, Nonce, aead::{Aead, KeyInit}};
+
+pub struct Aes256GcmHelper {
+    cipher: Aes256Gcm,
+    counter: u64,
+}
+
+impl Aes256GcmHelper {
+    pub fn new(key: &[u8]) -> Self {
+        let k = Key::<Aes256Gcm>::from_slice(key);
+        Self { cipher: Aes256Gcm::new(k), counter: 0 }
+    }
+
+    fn next_nonce(&mut self) -> [u8; 12] {
+        let mut nonce = [0u8; 12];
+        nonce[4..].copy_from_slice(&self.counter.to_be_bytes());
+        self.counter += 1;
+        nonce
+    }
+
+    pub fn encrypt(&mut self, plaintext: &[u8]) -> (Vec<u8>, [u8; 12]) {
+        let nonce_bytes = self.next_nonce();
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        let ct = self.cipher.encrypt(nonce, plaintext).expect("encryption failure");
+        (ct, nonce_bytes)
+    }
+
+    pub fn decrypt(&self, nonce: &[u8; 12], ciphertext: &[u8]) -> Option<Vec<u8>> {
+        let nonce = Nonce::from_slice(nonce);
+        self.cipher.decrypt(nonce, ciphertext).ok()
+    }
+}

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -1,0 +1,8 @@
+use sha2::{Sha256, Digest};
+use std::net::Ipv6Addr;
+
+pub fn make_ipv6_from_pubkey(pk: &[u8]) -> Ipv6Addr {
+    let hash = Sha256::digest(pk);
+    let bytes: [u8; 16] = hash[0..16].try_into().unwrap();
+    Ipv6Addr::from(bytes)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod pqc;
+pub mod crypto;
+pub mod ipv6;
+pub mod tundev;

--- a/src/pqc.rs
+++ b/src/pqc.rs
@@ -1,0 +1,26 @@
+use pqcrypto_traits::kem::{PublicKey as _, Ciphertext as _, SharedSecret as _};
+use pqcrypto_kyber::kyber512;
+use pqcrypto_kyber::kyber512::{PublicKey, SecretKey, Ciphertext};
+
+pub const PUBLIC_KEY_LEN: usize = kyber512::public_key_bytes();
+pub const SECRET_KEY_LEN: usize = kyber512::secret_key_bytes();
+pub const CIPHERTEXT_LEN: usize = kyber512::ciphertext_bytes();
+
+pub fn generate_keypair() -> (PublicKey, SecretKey) {
+    kyber512::keypair()
+}
+
+pub fn encapsulate(pk: &PublicKey) -> (Vec<u8>, Vec<u8>) {
+    let (ct, ss) = kyber512::encapsulate(pk);
+    (ct.as_bytes().to_vec(), ss.as_bytes().to_vec())
+}
+
+pub fn decapsulate(ciphertext: &[u8], sk: &SecretKey) -> Vec<u8> {
+    let ct = Ciphertext::from_bytes(ciphertext).expect("invalid ciphertext");
+    let ss = kyber512::decapsulate(&ct, sk);
+    ss.as_bytes().to_vec()
+}
+
+pub fn public_key_from_bytes(bytes: &[u8]) -> PublicKey {
+    PublicKey::from_bytes(bytes).expect("invalid public key")
+}

--- a/src/tundev.rs
+++ b/src/tundev.rs
@@ -1,0 +1,30 @@
+use std::io::{Read, Write};
+use tun::{Configuration, Layer};
+
+pub struct TunDevice {
+    dev: tun::platform::Device,
+}
+
+impl TunDevice {
+    pub fn create(name: &str) -> tun::Result<Self> {
+        let mut config = Configuration::default();
+        config
+            .name(name)
+            .layer(Layer::L3)
+            .up();
+        config.platform(|p| {
+            #[cfg(target_os = "linux")]
+            p.packet_information(false);
+        });
+        let dev = tun::create(&config)?;
+        Ok(Self { dev })
+    }
+
+    pub fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.dev.read(buf)
+    }
+
+    pub fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.dev.write(buf)
+    }
+}


### PR DESCRIPTION
## Summary
- initialize Cargo project with Kyber key exchange, AES-GCM and TUN deps
- implement PQC key exchange helpers
- add AES-256-GCM utilities
- derive IPv6 address from public key
- provide basic TUN device wrapper
- create client and server examples exchanging one encrypted packet

## Testing
- `cargo build --bins`

------
https://chatgpt.com/codex/tasks/task_e_686cbe4bdcfc8322a26638eb2a70e2dd