### PR TITLE
Implement UDP tunnel mode with TUN device

### DIFF
--- a/src/bin/nuntium.rs
+++ b/src/bin/nuntium.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
-use nuntium::modes::{run_client, run_server};
+use nuntium::modes::{run_client, run_server, run_client_tun, run_server_tun};
 
 #[derive(Parser)]
 struct Args {
-    /// Operating mode: 'client' or 'server'
+    /// Operating mode: 'client', 'server', 'client-tun', or 'server-tun'
     #[arg(long)]
     mode: String,
 }
@@ -13,6 +13,8 @@ fn main() -> std::io::Result<()> {
     match args.mode.as_str() {
         "client" => run_client(),
         "server" => run_server(),
+        "client-tun" => run_client_tun(),
+        "server-tun" => run_server_tun(),
         other => {
             eprintln!("unknown mode: {other}");
             std::process::exit(1);

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -1,6 +1,10 @@
 use pqcrypto_traits::kem::PublicKey as _;
+use std::collections::HashMap;
 use std::io::{Read, Write};
-use std::net::{TcpListener, TcpStream};
+use std::net::{TcpListener, TcpStream, UdpSocket, SocketAddr};
+use std::thread;
+
+use crate::tundev::TunDevice;
 
 use crate::{crypto::Aes256GcmHelper, ipv6::make_ipv6_from_pubkey, pqc};
 
@@ -91,4 +95,110 @@ pub fn run_server() -> std::io::Result<()> {
     stream.write_all(&ct_out)?;
 
     Ok(())
+}
+
+pub fn run_server_tun() -> std::io::Result<()> {
+    let (pk, sk) = pqc::generate_keypair();
+    let addr = make_ipv6_from_pubkey(pk.as_bytes());
+    println!("Server IPv6: {}", addr);
+
+    let socket = UdpSocket::bind("0.0.0.0:9001")?;
+    let mut clients: HashMap<SocketAddr, Aes256GcmHelper> = HashMap::new();
+
+    let mut buf = [0u8; 2048];
+    loop {
+        let (len, src) = socket.recv_from(&mut buf)?;
+
+        if !clients.contains_key(&src) {
+            if len == pqc::PUBLIC_KEY_LEN {
+                socket.send_to(pk.as_bytes(), src)?;
+            } else if len == pqc::CIPHERTEXT_LEN {
+                let shared = pqc::decapsulate(&buf[..len], &sk);
+                clients.insert(src, Aes256GcmHelper::new(&shared));
+                println!("New client registered: {src}");
+            }
+            continue;
+        }
+
+        if len < 14 {
+            continue;
+        }
+
+        let mut nonce = [0u8; 12];
+        nonce.copy_from_slice(&buf[..12]);
+        let l = u16::from_be_bytes([buf[12], buf[13]]) as usize;
+        if len < 14 + l {
+            continue;
+        }
+
+        // forward encrypted packet to all other clients
+        for (&addr, _) in clients.iter() {
+            if addr != src {
+                socket.send_to(&buf[..len], addr)?;
+            }
+        }
+    }
+}
+
+pub fn run_client_tun() -> std::io::Result<()> {
+    let (pk, _sk) = pqc::generate_keypair();
+    let addr = make_ipv6_from_pubkey(pk.as_bytes());
+    println!("Client IPv6: {}", addr);
+
+    let socket = UdpSocket::bind("0.0.0.0:0")?;
+    socket.connect("127.0.0.1:9001")?;
+
+    socket.send(pk.as_bytes())?;
+    let mut buf = vec![0u8; pqc::PUBLIC_KEY_LEN];
+    socket.recv(&mut buf)?;
+    let server_pk = pqc::public_key_from_bytes(&buf);
+    let (ct, shared) = pqc::encapsulate(&server_pk);
+    socket.send(&ct)?;
+    let aes_send = Aes256GcmHelper::new(&shared);
+    let aes_recv = Aes256GcmHelper::new(&shared);
+
+    let tun = TunDevice::create("nuntun")
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let tun = std::sync::Arc::new(std::sync::Mutex::new(tun));
+
+    let sock_clone = socket.try_clone()?;
+    let tun_clone = std::sync::Arc::clone(&tun);
+    thread::spawn(move || {
+        let mut recv_buf = [0u8; 2048];
+        let mut aes = aes_send; // encryption
+        loop {
+            let n = tun_clone
+                .lock()
+                .expect("lock tun")
+                .read(&mut recv_buf)
+                .expect("read tun");
+            let (ct, nonce) = aes.encrypt(&recv_buf[..n]);
+            let mut msg = Vec::with_capacity(14 + ct.len());
+            msg.extend_from_slice(&nonce);
+            msg.extend_from_slice(&(ct.len() as u16).to_be_bytes());
+            msg.extend_from_slice(&ct);
+            sock_clone.send(&msg).expect("send packet");
+        }
+    });
+
+    let mut recv_buf = [0u8; 2048];
+    let aes = aes_recv; // decryption
+    loop {
+        let n = socket.recv(&mut recv_buf)?;
+        if n < 14 {
+            continue;
+        }
+        let mut nonce = [0u8; 12];
+        nonce.copy_from_slice(&recv_buf[..12]);
+        let l = u16::from_be_bytes([recv_buf[12], recv_buf[13]]) as usize;
+        if n < 14 + l {
+            continue;
+        }
+        if let Some(plain) = aes.decrypt(&nonce, &recv_buf[14..14 + l]) {
+            tun
+                .lock()
+                .expect("lock tun")
+                .write(&plain)?;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- implement UDP relay server and client that use TUN devices
- wire new modes into `nuntium` binary

## Testing
- `cargo test`
- `cargo clippy` *(fails: `cargo-clippy` not installed)*
- `cargo fmt` *(fails: `cargo-fmt` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ccf0e58d483229ef0f86b7633868c