### PR TITLE
Add port config support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,3 +14,17 @@ pub fn read_server_ip() -> Option<String> {
         .map(|l| l.trim().to_string())
         .filter(|l| !l.is_empty())
 }
+
+/// Read the server port from `/etc/nuntium.conf`.
+///
+/// The port is expected to be specified on the second line of the file.
+/// Returns `None` if the file does not exist, the second line is missing, or
+/// parsing fails.
+pub fn read_server_port() -> Option<u16> {
+    let path = std::env::var("NUNTIUM_CONF").unwrap_or_else(|_| "/etc/nuntium.conf".to_string());
+    let content = fs::read_to_string(Path::new(&path)).ok()?;
+    content
+        .lines()
+        .nth(1)
+        .and_then(|l| l.trim().parse::<u16>().ok())
+}

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -14,7 +14,8 @@ pub fn run_client() -> std::io::Result<()> {
     println!("Client IPv6: {}", addr);
 
     let ip = config::read_server_ip().unwrap_or_else(|| "127.0.0.1".to_string());
-    let addr_str = format!("{ip}:9000");
+    let port = config::read_server_port().unwrap_or(9000);
+    let addr_str = format!("{ip}:{port}");
     let mut stream = TcpStream::connect(addr_str)?;
 
     // send client pk
@@ -55,7 +56,9 @@ pub fn run_client() -> std::io::Result<()> {
 pub fn run_server() -> std::io::Result<()> {
     let (pk, sk) = pqc::generate_keypair();
 
-    let listener = TcpListener::bind("0.0.0.0:9000")?;
+    let port = config::read_server_port().unwrap_or(9000);
+    let addr = format!("0.0.0.0:{port}");
+    let listener = TcpListener::bind(addr)?;
     let (mut stream, _) = listener.accept()?;
 
     // receive client pk

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,4 +1,4 @@
-use nuntium::config::read_server_ip;
+use nuntium::config::{read_server_ip, read_server_port};
 use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;
@@ -10,10 +10,13 @@ fn read_ip_from_config_file() {
     {
         let mut file = File::create(&file_path).unwrap();
         writeln!(file, "192.0.2.1").unwrap();
+        writeln!(file, "9000").unwrap();
     }
     std::env::set_var("NUNTIUM_CONF", &file_path);
     let ip = read_server_ip();
+    let port = read_server_port();
     assert_eq!(ip, Some("192.0.2.1".to_string()));
+    assert_eq!(port, Some(9000));
     std::env::remove_var("NUNTIUM_CONF");
 }
 
@@ -21,6 +24,8 @@ fn read_ip_from_config_file() {
 fn read_ip_missing_file() {
     std::env::set_var("NUNTIUM_CONF", "/nonexistent/nuntium.conf");
     let ip = read_server_ip();
+    let port = read_server_port();
     assert!(ip.is_none());
+    assert!(port.is_none());
     std::env::remove_var("NUNTIUM_CONF");
 }


### PR DESCRIPTION
## Summary
- parse server port from `/etc/nuntium.conf`
- connect and listen on that port
- test new port config logic

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' not installed)*
- `cargo test`
- `cargo clippy` *(fails: 'cargo-clippy' not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686deed56c54832287f7424867b6a309