### PR TITLE
Convert config to JSON

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ rand = "0.8"
 sha2 = "0.10"
 tun = "0.6"
 clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,30 +1,31 @@
+use serde::Deserialize;
 use std::fs;
 use std::path::Path;
 
-/// Read the server IP address from `/etc/nuntium.conf`.
-///
-/// The file is expected to contain the IP address on the first line.
-/// Returns `None` if the file does not exist or is empty.
-pub fn read_server_ip() -> Option<String> {
+#[derive(Deserialize)]
+struct Config {
+    ip: Option<String>,
+    port: Option<u16>,
+}
+
+fn read_config() -> Option<Config> {
     let path = std::env::var("NUNTIUM_CONF").unwrap_or_else(|_| "/etc/nuntium.conf".to_string());
     let content = fs::read_to_string(Path::new(&path)).ok()?;
-    content
-        .lines()
-        .next()
-        .map(|l| l.trim().to_string())
-        .filter(|l| !l.is_empty())
+    serde_json::from_str(&content).ok()
+}
+
+/// Read the server IP address from `/etc/nuntium.conf`.
+///
+/// The configuration file is expected to contain a JSON object with an `ip`
+/// field. Returns `None` if the file does not exist or if parsing fails.
+pub fn read_server_ip() -> Option<String> {
+    read_config()?.ip
 }
 
 /// Read the server port from `/etc/nuntium.conf`.
 ///
-/// The port is expected to be specified on the second line of the file.
-/// Returns `None` if the file does not exist, the second line is missing, or
-/// parsing fails.
+/// The configuration file is expected to contain a JSON object with a `port`
+/// field. Returns `None` if the file does not exist or if parsing fails.
 pub fn read_server_port() -> Option<u16> {
-    let path = std::env::var("NUNTIUM_CONF").unwrap_or_else(|_| "/etc/nuntium.conf".to_string());
-    let content = fs::read_to_string(Path::new(&path)).ok()?;
-    content
-        .lines()
-        .nth(1)
-        .and_then(|l| l.trim().parse::<u16>().ok())
+    read_config()?.port
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -9,8 +9,7 @@ fn read_ip_from_config_file() {
     let file_path = dir.path().join("nuntium.conf");
     {
         let mut file = File::create(&file_path).unwrap();
-        writeln!(file, "192.0.2.1").unwrap();
-        writeln!(file, "9000").unwrap();
+        write!(file, "{{\"ip\":\"192.0.2.1\",\"port\":9000}}").unwrap();
     }
     std::env::set_var("NUNTIUM_CONF", &file_path);
     let ip = read_server_ip();


### PR DESCRIPTION
## Summary
- parse `nuntium.conf` as JSON using serde
- adjust test to write JSON configuration
- add serde dependencies

## Testing
- `cargo test --quiet`
- `cargo clippy --quiet` *(fails: component missing)*
- `cargo fmt` *(fails: component missing)*

------
https://chatgpt.com/codex/tasks/task_e_686df0c91c6883229a5591e1afc97077