### PR TITLE
Harmonize IPv6 derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Once a shared secret is established, all messages are encrypted with AES-256-GCM
 
 ## IPv6 Address Derivation
 
-The shared secret also deterministically maps to an IPv6 address. Derive a 128-bit value from the secret (e.g. using a cryptographic hash) and use it as the host portion of an IPv6 address. This allows peers to discover each other based solely on the key exchange.
+Each public key deterministically maps to an IPv6 address. Hash the key with
+SHA-256 and truncate the result to 128 bits to form the host portion of the
+address. This stable mapping lets peers identify each other without additional
+configuration.
 
 ## Building
 

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -1,7 +1,9 @@
 use sha2::{Sha256, Digest};
 use std::net::Ipv6Addr;
 
-pub fn make_ipv6_from_pubkey(pk: &[u8]) -> Ipv6Addr {
+/// Derive an IPv6 address from a public key by hashing it with SHA-256 and
+/// truncating the result to 128 bits.
+pub fn ipv6_from_public_key(pk: &[u8]) -> Ipv6Addr {
     let hash = Sha256::digest(pk);
     let bytes: [u8; 16] = hash[0..16].try_into().unwrap();
     Ipv6Addr::from(bytes)

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -6,11 +6,11 @@ use std::thread;
 
 use crate::tundev::TunDevice;
 
-use crate::{crypto::Aes256GcmHelper, ipv6::make_ipv6_from_pubkey, pqc, config};
+use crate::{crypto::Aes256GcmHelper, ipv6::ipv6_from_public_key, pqc, config};
 
 pub fn run_client() -> std::io::Result<()> {
     let (pk, _sk) = pqc::generate_keypair();
-    let addr = make_ipv6_from_pubkey(pk.as_bytes());
+    let addr = ipv6_from_public_key(pk.as_bytes());
     println!("Client IPv6: {}", addr);
 
     let ip = config::read_server_ip().unwrap_or_else(|| "127.0.0.1".to_string());
@@ -65,7 +65,7 @@ pub fn run_server() -> std::io::Result<()> {
     let mut client_pk_bytes = vec![0u8; pqc::PUBLIC_KEY_LEN];
     stream.read_exact(&mut client_pk_bytes)?;
     let client_pk = pqc::public_key_from_bytes(&client_pk_bytes);
-    let client_addr = make_ipv6_from_pubkey(client_pk.as_bytes());
+    let client_addr = ipv6_from_public_key(client_pk.as_bytes());
     println!("Client IPv6: {}", client_addr);
 
     // send server pk
@@ -143,7 +143,7 @@ pub fn run_server_tun() -> std::io::Result<()> {
 
 pub fn run_client_tun() -> std::io::Result<()> {
     let (pk, _sk) = pqc::generate_keypair();
-    let addr = make_ipv6_from_pubkey(pk.as_bytes());
+    let addr = ipv6_from_public_key(pk.as_bytes());
     println!("Client IPv6: {}", addr);
 
     let socket = UdpSocket::bind("0.0.0.0:0")?;

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -1,11 +1,11 @@
 use std::net::Ipv6Addr;
-use nuntium::{ipv6::make_ipv6_from_pubkey, pqc, crypto::Aes256GcmHelper};
+use nuntium::{ipv6::ipv6_from_public_key, pqc, crypto::Aes256GcmHelper};
 
 #[test]
 fn ipv6_derivation_from_known_key() {
     // deterministic 32-byte public key 0..31
     let pk: Vec<u8> = (0u8..32).collect();
-    let addr = make_ipv6_from_pubkey(&pk);
+    let addr = ipv6_from_public_key(&pk);
     let expected_bytes = [
         0x63, 0x0d, 0xcd, 0x29, 0x66, 0xc4, 0x33, 0x66,
         0x91, 0x12, 0x54, 0x48, 0xbb, 0xb2, 0x5b, 0x4f,


### PR DESCRIPTION
## Summary
- derive IPv6 addresses from the public key
- rename helper to `ipv6_from_public_key`
- adjust client/server code to use the new name
- update tests and documentation

## Testing
- `cargo fmt --all -- --force` *(fails: expected identifier, found `_`)*
- `cargo clippy` *(fails: 'cargo-clippy' is not installed)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686e14d422f48322be086428d57db1da