### PR TITLE
Implement automatic IPv6 assignment for TUN

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ cargo test
 
 Nuntium also supports a virtual IPv6 overlay built on TUN devices. Each
 client creates its own TUN interface and assigns the IPv6 address
-derived from its public key. Packets read from this interface are
+derived from its public key. The address is configured automatically on
+the interface with a `/64` prefix using the host's networking tools
+(e.g. `ip`). If the assignment fails, a warning is printed. Packets read
+from this interface are
 encrypted and sent over UDP to a relay server. The server merely
 forwards packets between clients and does not require its own address.
 

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -162,6 +162,9 @@ pub fn run_client_tun() -> std::io::Result<()> {
 
     let tun = TunDevice::create("nuntun")
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    if let Err(e) = tun.assign_ipv6(addr) {
+        eprintln!("Failed to assign IPv6 address: {e}");
+    }
     let tun = std::sync::Arc::new(std::sync::Mutex::new(tun));
 
     let sock_clone = socket.try_clone()?;

--- a/src/tundev.rs
+++ b/src/tundev.rs
@@ -1,5 +1,6 @@
 use std::io::{Read, Write};
-use tun::{Configuration, Layer};
+use std::process::Command;
+use tun::{Configuration, Layer, Device};
 
 pub struct TunDevice {
     dev: tun::platform::Device,
@@ -18,6 +19,30 @@ impl TunDevice {
         });
         let dev = tun::create(&config)?;
         Ok(Self { dev })
+    }
+
+    pub fn name(&self) -> Result<String, tun::Error> {
+        self.dev.name()
+    }
+
+    pub fn assign_ipv6(&self, addr: std::net::Ipv6Addr) -> std::io::Result<()> {
+        #[cfg(target_os = "linux")]
+        {
+            let name = self
+                .dev
+                .name()
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            let status = Command::new("ip")
+                .args(["-6", "addr", "add", &format!("{}/64", addr), "dev", &name])
+                .status()?;
+            if !status.success() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "ip addr add failed",
+                ));
+            }
+        }
+        Ok(())
     }
 
     pub fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {


### PR DESCRIPTION
## Summary
- automatically configure TUN interface with derived IPv6 address
- log failures if address assignment fails
- document address assignment in README

## Testing
- `cargo fmt` *(fails: `'cargo-fmt' is not installed`)*
- `cargo clippy -- -D warnings` *(fails: `'cargo-clippy' is not installed`)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686e18db70e88322b2993b8a19aa2ea9