### PR TITLE
Switch TUN setup to /7 prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cargo test
 Nuntium also supports a virtual IPv6 overlay built on TUN devices. Each
 client creates its own TUN interface and assigns the IPv6 address
 derived from its public key. The address is configured automatically on
-the interface with a `/64` prefix using the host's networking tools
+the interface with a `/7` prefix using the host's networking tools
 (e.g. `ip`). If the assignment fails, a warning is printed. Packets read
 from this interface are
 encrypted and sent over UDP to a relay server. The server merely

--- a/tests/tun.rs
+++ b/tests/tun.rs
@@ -1,0 +1,19 @@
+#[cfg(target_os = "linux")]
+use nuntium::tundev::TunDevice;
+#[cfg(target_os = "linux")]
+use std::net::Ipv6Addr;
+
+#[cfg(target_os = "linux")]
+#[test]
+fn ip_args_use_prefix_7() {
+    let addr = Ipv6Addr::new(0x4000, 0, 0, 0, 0, 0, 0, 1);
+    let args = TunDevice::ip_args(addr, "test0");
+    assert_eq!(args, vec![
+        "-6".to_string(),
+        "addr".to_string(),
+        "add".to_string(),
+        format!("{}/7", addr),
+        "dev".to_string(),
+        "test0".to_string(),
+    ]);
+}


### PR DESCRIPTION
## Summary
- configure Linux TUN interfaces with a `/7` prefix
- document the `/7` prefix in the README
- expose helper to build `ip` arguments and test it

## Testing
- `cargo test`
- `cargo fmt` *(fails: 'cargo-fmt' not installed)*
- `cargo clippy -- -D warnings` *(fails: 'cargo-clippy' not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e2798f09c8322a6a5b0c83bb3ed5d