### PR TITLE
Align IPv6 derivation with README

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,3 +6,25 @@ pub struct ServerConfig {
     pub ip: IpAddr,
     pub port: u16,
 }
+use std::env;
+use std::fs;
+use std::io;
+
+/// Read the server configuration file and return the deserialized structure.
+fn read_config() -> io::Result<ServerConfig> {
+    let path = env::var("NUNTIUM_CONF").unwrap_or_else(|_| "/etc/nuntium.conf".into());
+    let contents = fs::read_to_string(path)?;
+    let cfg: ServerConfig = serde_json::from_str(&contents)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    Ok(cfg)
+}
+
+/// Return the server IP address from configuration if available.
+pub fn read_server_ip() -> Option<String> {
+    read_config().ok().map(|c| c.ip.to_string())
+}
+
+/// Return the server port from configuration if available.
+pub fn read_server_port() -> Option<u16> {
+    read_config().ok().map(|c| c.port)
+}

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,35 @@
+use aes_gcm::{
+    aead::{Aead, KeyInit},
+    Aes256Gcm, Nonce,
+};
+
+/// Helper wrapper around AES-256-GCM providing simple encrypt/decrypt methods
+/// with monotonically increasing nonces.
+pub struct Aes256GcmHelper {
+    cipher: Aes256Gcm,
+    counter: u128,
+}
+
+impl Aes256GcmHelper {
+    pub fn new(key: &[u8; 32]) -> Self {
+        let cipher = Aes256Gcm::new(key.into());
+        Self { cipher, counter: 0 }
+    }
+
+    pub fn encrypt(&mut self, plaintext: &[u8]) -> (Vec<u8>, [u8; 12]) {
+        let nonce_bytes = self.counter.to_be_bytes();
+        let nonce_arr: [u8; 12] = nonce_bytes[4..].try_into().unwrap();
+        let nonce = Nonce::from_slice(&nonce_arr);
+        let ciphertext = self
+            .cipher
+            .encrypt(nonce, plaintext)
+            .expect("encryption failure");
+        self.counter += 1;
+        (ciphertext, nonce_arr)
+    }
+
+    pub fn decrypt(&self, nonce: &[u8; 12], ciphertext: &[u8]) -> Option<Vec<u8>> {
+        let nonce = Nonce::from_slice(nonce);
+        self.cipher.decrypt(nonce, ciphertext).ok()
+    }
+}

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -1,0 +1,39 @@
+use std::net::Ipv6Addr;
+
+/// Derive an IPv6 address from a Kyber public key by bitwise inverting the key
+/// bytes and embedding the resulting bit sequence under the `4000::/7` prefix.
+/// Leading zero bits of the inverted key are skipped. The next 121 bits fill the
+/// suffix of the IPv6 address. If fewer than 121 bits remain, the suffix is
+/// padded with zeros.
+pub fn ipv6_from_public_key(pk: &[u8]) -> Ipv6Addr {
+    let mut bits = Vec::with_capacity(pk.len() * 8);
+    for &b in pk {
+        let inv = !b;
+        for i in (0..8).rev() {
+            bits.push((inv >> i) & 1);
+        }
+    }
+
+    // Remove leading zeros until the first '1' bit
+    while let Some(0) = bits.first() {
+        bits.remove(0);
+    }
+
+    // Take exactly 121 bits for the suffix
+    bits.resize(121, 0);
+
+    let mut addr = [0u8; 16];
+    // Prefix 4000::/7 -> binary 0100_000, plus first suffix bit
+    addr[0] = 0b0100_0000 | bits[0];
+    let mut idx = 1;
+    for byte in &mut addr[1..] {
+        let mut b = 0u8;
+        for _ in 0..8 {
+            b = (b << 1) | bits[idx];
+            idx += 1;
+        }
+        *byte = b;
+    }
+
+    Ipv6Addr::from(addr)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod config;
+pub mod crypto;
+pub mod ipv6;
+pub mod pqc;
+pub mod tundev;

--- a/src/pqc.rs
+++ b/src/pqc.rs
@@ -1,0 +1,16 @@
+use pqcrypto_kyber::kyber1024;
+use pqcrypto_kyber::kyber1024::{Ciphertext, PublicKey, SecretKey, SharedSecret};
+
+/// Wrapper functions around pqcrypto-kyber for easier testing
+pub fn generate_keypair() -> (PublicKey, SecretKey) {
+    kyber1024::keypair()
+}
+
+pub fn encapsulate(pk: &PublicKey) -> (Ciphertext, SharedSecret) {
+    let (ss, ct) = kyber1024::encapsulate(pk);
+    (ct, ss)
+}
+
+pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
+    kyber1024::decapsulate(ct, sk)
+}

--- a/src/tundev.rs
+++ b/src/tundev.rs
@@ -1,0 +1,16 @@
+use std::net::Ipv6Addr;
+
+pub struct TunDevice;
+
+impl TunDevice {
+    pub fn ip_args(addr: Ipv6Addr, name: &str) -> Vec<String> {
+        vec![
+            "-6".to_string(),
+            "addr".to_string(),
+            "add".to_string(),
+            format!("{}/7", addr),
+            "dev".to_string(),
+            name.to_string(),
+        ]
+    }
+}

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -1,5 +1,6 @@
+use nuntium::{crypto::Aes256GcmHelper, ipv6::ipv6_from_public_key, pqc};
+use pqcrypto_traits::kem::SharedSecret as _;
 use std::net::Ipv6Addr;
-use nuntium::{ipv6::ipv6_from_public_key, pqc, crypto::Aes256GcmHelper};
 
 #[test]
 fn ipv6_derivation_from_known_key() {
@@ -7,8 +8,8 @@ fn ipv6_derivation_from_known_key() {
     let pk: Vec<u8> = (0u8..32).collect();
     let addr = ipv6_from_public_key(&pk);
     let expected_bytes = [
-        0x41, 0xff, 0xfd, 0xfb, 0xf9, 0xf7, 0xf5, 0xf3,
-        0xf1, 0xef, 0xed, 0xeb, 0xe9, 0xe7, 0xe5, 0xe3,
+        0x41, 0xff, 0xfd, 0xfb, 0xf9, 0xf7, 0xf5, 0xf3, 0xf1, 0xef, 0xed, 0xeb, 0xe9, 0xe7, 0xe5,
+        0xe3,
     ];
     let expected = Ipv6Addr::from(expected_bytes);
     assert_eq!(addr, expected);
@@ -19,7 +20,7 @@ fn kyber512_handshake_shared_secret() {
     let (server_pk, server_sk) = pqc::generate_keypair();
     let (ct, client_ss) = pqc::encapsulate(&server_pk);
     let server_ss = pqc::decapsulate(&ct, &server_sk);
-    assert_eq!(client_ss, server_ss);
+    assert_eq!(client_ss.as_bytes(), server_ss.as_bytes());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add library modules for pqc, crypto and IPv6 logic
- implement bitwise-inversion IPv6 derivation
- expose helper functions for tests
- adjust protocol test for new API

## Testing
- `cargo clippy --lib -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687fb854e38483228b6d1db40e758e80