### PR TITLE
Fix kyber request deserialization

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -1,15 +1,11 @@
+use nuntium::protocol::{
+    MSG_TYPE_ENCRYPTED_PACKET, MSG_TYPE_KEY_EXCHANGE, MSG_TYPE_LISTEN, MSG_TYPE_QUERY,
+    MSG_TYPE_QUERY_RESPONSE, MSG_TYPE_REGISTER,
+};
 use pqcrypto_kyber::kyber1024;
 use pqcrypto_traits::kem::{Ciphertext, PublicKey};
-use std::io::{self, Read, Write, ErrorKind};
+use std::io::{self, ErrorKind, Read, Write};
 use std::net::{IpAddr, Ipv6Addr, SocketAddr, TcpStream};
-use nuntium::protocol::{
-    MSG_TYPE_ENCRYPTED_PACKET,
-    MSG_TYPE_KEY_EXCHANGE,
-    MSG_TYPE_LISTEN,
-    MSG_TYPE_QUERY,
-    MSG_TYPE_QUERY_RESPONSE,
-    MSG_TYPE_REGISTER,
-};
 
 /// リクエストの種類
 pub enum Request {
@@ -38,7 +34,10 @@ pub enum Request {
 impl Request {
     pub fn to_bytes(&self) -> Vec<u8> {
         match self {
-            Request::Register { public_key, ipv6_addr } => {
+            Request::Register {
+                public_key,
+                ipv6_addr,
+            } => {
                 let mut buf = Vec::with_capacity(1 + public_key.as_bytes().len() + 16);
                 buf.push(MSG_TYPE_REGISTER);
                 buf.extend_from_slice(public_key.as_bytes());
@@ -57,7 +56,10 @@ impl Request {
                 buf.extend_from_slice(&ipv6_addr.octets());
                 buf
             }
-            Request::KeyExchange { dst_ipv6, ciphertext } => {
+            Request::KeyExchange {
+                dst_ipv6,
+                ciphertext,
+            } => {
                 let ct = ciphertext.as_bytes();
                 let mut buf = Vec::with_capacity(1 + 16 + ct.len());
                 buf.push(MSG_TYPE_KEY_EXCHANGE);
@@ -65,7 +67,12 @@ impl Request {
                 buf.extend_from_slice(ct);
                 buf
             }
-            Request::EncryptedPacket { src_ipv6, dst_ipv6, nonce, payload } => {
+            Request::EncryptedPacket {
+                src_ipv6,
+                dst_ipv6,
+                nonce,
+                payload,
+            } => {
                 let mut buf = Vec::with_capacity(1 + 16 + 16 + 12 + payload.len());
                 buf.push(MSG_TYPE_ENCRYPTED_PACKET);
                 buf.extend_from_slice(&src_ipv6.octets());
@@ -84,47 +91,77 @@ impl Request {
         match buf[0] {
             MSG_TYPE_REGISTER => {
                 if buf.len() < 1 + 1584 + 16 {
-                    return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "invalid register"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "invalid register",
+                    ));
                 }
-                let pk = PublicKey::from_bytes(&buf[1..1 + 1584]).map_err(|e| {
+                let pk = kyber1024::PublicKey::from_bytes(&buf[1..1 + 1584]).map_err(|e| {
                     io::Error::new(ErrorKind::InvalidData, format!("Invalid public key: {e}"))
                 })?;
-                let ipv6 = Ipv6Addr::from(<[u8; 16]>::try_from(&buf[1 + 1584..1 + 1584 + 16]).unwrap());
-                Ok(Request::Register { public_key: pk?, ipv6_addr: ipv6 })
+                let ipv6 =
+                    Ipv6Addr::from(<[u8; 16]>::try_from(&buf[1 + 1584..1 + 1584 + 16]).unwrap());
+                Ok(Request::Register {
+                    public_key: pk,
+                    ipv6_addr: ipv6,
+                })
             }
             MSG_TYPE_QUERY => {
                 if buf.len() < 1 + 16 {
-                    return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "invalid query"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "invalid query",
+                    ));
                 }
                 let ipv6 = Ipv6Addr::from(<[u8; 16]>::try_from(&buf[1..17]).unwrap());
                 Ok(Request::Query { ipv6_addr: ipv6 })
             }
             MSG_TYPE_LISTEN => {
                 if buf.len() < 1 + 16 {
-                    return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "invalid listen"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "invalid listen",
+                    ));
                 }
                 let ipv6 = Ipv6Addr::from(<[u8; 16]>::try_from(&buf[1..17]).unwrap());
                 Ok(Request::Listen { ipv6_addr: ipv6 })
             }
             MSG_TYPE_KEY_EXCHANGE => {
                 if buf.len() < 1 + 16 + 1568 {
-                    return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "invalid keyexchange"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "invalid keyexchange",
+                    ));
                 }
                 let dst = Ipv6Addr::from(<[u8; 16]>::try_from(&buf[1..17]).unwrap());
-                let ct = Ciphertext::from_bytes(&buf[17..]).map_err(|e| {
-                    io::Error::new(ErrorKind::InvalidData, format!("Invalid Kyber ciphertext: {e}"))
+                let ct = kyber1024::Ciphertext::from_bytes(&buf[17..]).map_err(|e| {
+                    io::Error::new(
+                        ErrorKind::InvalidData,
+                        format!("Invalid Kyber ciphertext: {e}"),
+                    )
                 })?;
-                Ok(Request::KeyExchange { dst_ipv6: dst, ciphertext: ct? })
+                Ok(Request::KeyExchange {
+                    dst_ipv6: dst,
+                    ciphertext: ct,
+                })
             }
             MSG_TYPE_ENCRYPTED_PACKET => {
                 if buf.len() < 1 + 16 + 16 + 12 {
-                    return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "invalid packet"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "invalid packet",
+                    ));
                 }
                 let src = Ipv6Addr::from(<[u8; 16]>::try_from(&buf[1..17]).unwrap());
                 let dst = Ipv6Addr::from(<[u8; 16]>::try_from(&buf[17..33]).unwrap());
                 let nonce: [u8; 12] = buf[33..45].try_into().unwrap();
                 let payload = buf[45..].to_vec();
-                Ok(Request::EncryptedPacket { src_ipv6: src, dst_ipv6: dst, nonce, payload })
+                Ok(Request::EncryptedPacket {
+                    src_ipv6: src,
+                    dst_ipv6: dst,
+                    nonce,
+                    payload,
+                })
             }
             _ => Err(io::Error::new(io::ErrorKind::InvalidData, "unknown type")),
         }
@@ -139,14 +176,17 @@ impl Request {
         if matches!(self, Request::Query { .. }) {
             let mut buf = Vec::new();
             stream.read_to_end(&mut buf)?;
-            if buf.get(0) == Some(&MSG_TYPE_QUERY_RESPONSE) {
+            if buf.first() == Some(&MSG_TYPE_QUERY_RESPONSE) {
                 if buf.get(1) == Some(&1) {
                     Ok(Some(buf[2..].to_vec()))
                 } else {
                     Ok(None)
                 }
             } else {
-                Err(io::Error::new(io::ErrorKind::InvalidData, "invalid response"))
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid response",
+                ))
             }
         } else {
             Ok(None)

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,3 @@
-use hex;
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::{self, Read, Write};
@@ -10,12 +9,8 @@ use std::thread;
 use crate::client_info::{save_client_info, ClientInfo};
 use crate::path_manager::PathManager;
 use nuntium::protocol::{
-    MSG_TYPE_ENCRYPTED_PACKET,
-    MSG_TYPE_KEY_EXCHANGE,
-    MSG_TYPE_LISTEN,
-    MSG_TYPE_QUERY,
-    MSG_TYPE_QUERY_RESPONSE,
-    MSG_TYPE_REGISTER,
+    MSG_TYPE_ENCRYPTED_PACKET, MSG_TYPE_KEY_EXCHANGE, MSG_TYPE_LISTEN, MSG_TYPE_QUERY,
+    MSG_TYPE_QUERY_RESPONSE, MSG_TYPE_REGISTER,
 };
 
 type ClientMap = Arc<Mutex<HashMap<Ipv6Addr, TcpStream>>>;
@@ -112,12 +107,18 @@ fn handle_register(stream: &mut TcpStream, db_path: &Path, _clients: &ClientMap)
     let ipv6_bytes = &buf[1584..];
     let ipv6_addr = Ipv6Addr::from(<[u8; 16]>::try_from(ipv6_bytes).unwrap());
 
-    println!("✅ Received public key (first 8 bytes): {:02X?}", &public_key_bytes[..8]);
+    println!(
+        "✅ Received public key (first 8 bytes): {:02X?}",
+        &public_key_bytes[..8]
+    );
     println!("✅ IPv6 address: {}", ipv6_addr);
 
     let client_info = ClientInfo {
         ipv6: ipv6_addr.to_string(),
-        public_key_hex: public_key_bytes.iter().map(|b| format!("{:02X}", b)).collect(),
+        public_key_hex: public_key_bytes
+            .iter()
+            .map(|b| format!("{:02X}", b))
+            .collect(),
     };
     save_client_info(client_info, db_path)?;
 

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Read};
+use std::io::{self};
 use std::net::Ipv6Addr;
 use std::process::Command;
 use tun::{Configuration, Device};


### PR DESCRIPTION
## Summary
- use concrete kyber types when reading request messages
- clean up unused imports in client, server and tun modules
- remove stray '?' operators when constructing requests

## Testing
- `cargo build`
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688091104ed483228e8f57eb290fcf62