### PR TITLE
Add protocol constants for message sizes

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -5,3 +5,17 @@ pub const MSG_TYPE_REGISTER: u8 = 0x10;
 pub const MSG_TYPE_QUERY: u8 = 0x11;
 pub const MSG_TYPE_QUERY_RESPONSE: u8 = 0x12;
 pub const MSG_TYPE_LISTEN: u8 = 0x13;
+
+// === Size constants ===
+pub const KYBER_PUBLIC_KEY_SIZE: usize = 1584;
+pub const KYBER_CIPHERTEXT_SIZE: usize = 1568;
+pub const IPV6_ADDR_SIZE: usize = 16;
+pub const NONCE_SIZE: usize = 12;
+
+// === Computed frame lengths ===
+pub const REGISTER_MSG_SIZE: usize = 1 + KYBER_PUBLIC_KEY_SIZE + IPV6_ADDR_SIZE;
+pub const KEY_EXCHANGE_MSG_SIZE: usize = 1 + IPV6_ADDR_SIZE + KYBER_CIPHERTEXT_SIZE;
+pub const ENCRYPTED_PACKET_HEADER_SIZE: usize = 1 + IPV6_ADDR_SIZE * 2 + NONCE_SIZE;
+pub const QUERY_MSG_SIZE: usize = 1 + IPV6_ADDR_SIZE;
+pub const LISTEN_MSG_SIZE: usize = 1 + IPV6_ADDR_SIZE;
+pub const MTU: usize = 1500;

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -4,8 +4,7 @@ use std::process::Command;
 use tun::{Configuration, Device};
 
 use crate::packet::{parse_ipv6_packet, UpperLayerPacket};
-
-const MTU: usize = 1500;
+use crate::protocol::MTU;
 
 /// Create a TUN device and assign an IPv6 address
 pub fn create_tun(ipv6_addr: Ipv6Addr) -> io::Result<(impl Device, String)> {


### PR DESCRIPTION
## Summary
- define shared constants for key sizes, nonce size, IPv6 size and message lengths
- update client, server, request and tun code to use the new constants

## Testing
- `cargo clippy --quiet`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68809b8eb1f08322861ccd7d7adb1e2a