### PR TITLE
Translate comments to English and add Japanese README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-# 🏗 ビルドステージ
+# 🏗 Build stage
 FROM ubuntu:22.04 AS builder
 
-# 開発環境セットアップ
+# Set up development environment
 RUN apt-get update && apt-get install -y \
     curl build-essential pkg-config libssl-dev \
     git iproute2 iputils-ping net-tools sudo \
@@ -14,10 +14,10 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 WORKDIR /app
 COPY . .
 
-# ビルド（リリースビルド）
+# Build (release)
 RUN cargo build --release
 
-# 🚀 ランタイムステージ
+# 🚀 Runtime stage
 FROM ubuntu:22.04
 
 COPY wait-for-it.sh /usr/local/bin/wait-for-it.sh
@@ -31,5 +31,5 @@ COPY --from=builder /app/target/release/nuntium /usr/local/bin/nuntium
 
 COPY nuntium.conf /opt/nuntium/nuntium.conf
 
-# CMD は初期動作確認用にヘルプ表示（--mode は docker run 側で指定する）
+# Show help by default for initial verification (`--mode` is specified via docker run)
 CMD ["/usr/local/bin/nuntium", "--help"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Nuntium
+
+Nuntium は Kyber を用いた鍵交換と AES-256-GCM による暗号化を組み合わせ、IPv6 上で安全な通信を行うための実験的なツールです。
+
+## 主な機能
+
+- Kyber で生成された公開鍵から IPv6 アドレスを導出
+- TUN デバイスを介したパケット転送
+- AES-256-GCM によるペイロード暗号化
+- サーバーを介した公開鍵の共有と暗号化データの中継
+
+## ビルドとテスト
+
+Rust 2021 edition に対応しています。開発時は以下のコマンドでコード整形と検証を行ってください。
+
+```bash
+cargo fmt
+cargo clippy -- -D warnings
+cargo test
+```
+
+## 実行方法
+
+サーバーを起動する:
+
+```bash
+cargo run -- server
+```
+
+クライアントを起動する:
+
+```bash
+cargo run -- client
+```
+
+設定は `nuntium.conf` で行います。
+

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -1,14 +1,14 @@
-use aes_gcm::aead::Aead; // ✅ 実行用
+use aes_gcm::aead::Aead; // For runtime use
 use aes_gcm::KeyInit;
-use aes_gcm::{Aes256Gcm, Key, Nonce}; // ✅ 暗号本体 // ✅ .new() を使うために必要
+use aes_gcm::{Aes256Gcm, Key, Nonce}; // Cipher implementation and helper types
 
 pub fn encrypt_packet(key: &[u8], plaintext: &[u8]) -> Vec<u8> {
     let key = aes_gcm::Key::<Aes256Gcm>::from_slice(&key[..32]);
 
     let cipher = Aes256Gcm::new(key);
 
-    let nonce = Nonce::from_slice(&[0u8; 12]); // ← 固定値は安全性低いが、まず動作確認用
-    cipher.encrypt(nonce, plaintext).expect("暗号化失敗")
+    let nonce = Nonce::from_slice(&[0u8; 12]); // Using a fixed nonce is insecure but fine for initial testing
+    cipher.encrypt(nonce, plaintext).expect("encryption failed")
 }
 
 pub fn decrypt_packet(key: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, String> {
@@ -19,5 +19,5 @@ pub fn decrypt_packet(key: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, String> 
     let nonce = Nonce::from_slice(&[0u8; 12]);
     cipher
         .decrypt(nonce, ciphertext)
-        .map_err(|e| format!("復号失敗: {:?}", e))
+        .map_err(|e| format!("decryption failed: {:?}", e))
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -3,52 +3,52 @@ use std::net::Ipv6Addr;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum ServerError {
-    /// 公開鍵が見つからなかった
+    /// Public key not found
     KeyNotFound(Ipv6Addr),
 
-    /// クライアントが未登録
+    /// Client is not registered
     UnregisteredClient,
 
-    /// 宛先クライアントがオフライン
+    /// Destination client is offline
     DestinationUnavailable(Ipv6Addr),
 
-    /// 不正な要求
+    /// Invalid request
     InvalidRequest(String),
 
-    /// サーバー内部エラー
+    /// Internal server error
     InternalError(String),
 
-    /// クライアントのアドレスが無効
+    /// Client address is invalid
     InvalidAddress,
 
-    /// 排他制御のロックが破損
+    /// Mutex lock was poisoned
     LockPoisoned,
 
-    /// ストレージへの保存に失敗
+    /// Failed to save to storage
     StorageFailure,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Message {
-    /// クライアント登録要求 (c -> s)
+    /// Client registration request (c -> s)
     Register {
         address: Ipv6Addr,
         public_key: Vec<u8>,
     },
 
-    /// クライアント登録応答 (s -> c)
+    /// Client registration response (s -> c)
     RegisterResponse { result: Result<(), ServerError> },
 
-    /// 公開鍵要求 (c -> s)
+    /// Public key request (c -> s)
     KeyRequest { target_address: Ipv6Addr },
 
-    /// 公開鍵応答 (s -> c)
+    /// Public key response (s -> c)
     KeyResponse {
         target_address: Ipv6Addr,
         result: Result<Vec<u8>, ServerError>, // OK
     },
 
-    /// encrypted_payload を送信する (c -> s)
+    /// Send encrypted_payload (c -> s)
     SendEncryptedData {
         source: Ipv6Addr,
         destination: Ipv6Addr,
@@ -56,19 +56,19 @@ pub enum Message {
         encrypted_payload: Vec<u8>,
     },
 
-    /// encrypted_payload を受信する (s -> c)
+    /// Receive encrypted_payload (s -> c)
     ReceiveEncryptedData {
         source: Ipv6Addr,
         ciphertext: Option<Vec<u8>>,
         encrypted_payload: Vec<u8>,
     },
 
-    /// フォワーディングされた暗号通信 (s -> c2)
+    /// Forwarded encrypted communication (s -> c2)
     ForwardedData {
         source: Ipv6Addr,
         encrypted_payload: Vec<u8>,
     },
 
-    /// エラーメッセージ (s -> c)
+    /// Error message (s -> c)
     Error(ServerError),
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,9 @@
 use crate::path_manager::CONFIG_FILE;
 use serde::Deserialize;
+use std::env;
 use std::fs;
 use std::net::Ipv4Addr;
-use std::path::Path;
+use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 pub struct Config {
@@ -10,10 +11,30 @@ pub struct Config {
     pub port: u16,
 }
 
-/// JSON 設定ファイルを読み込む
-pub fn load_config() -> Result<Config, String> {
-    let path = Path::new(CONFIG_FILE);
-    let text = fs::read_to_string(path).map_err(|e| format!("設定ファイル読み込み失敗: {}", e))?;
+/// Determine configuration file path, optionally using the `NUNTIUM_CONF` environment variable
+fn config_path() -> PathBuf {
+    env::var("NUNTIUM_CONF")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(CONFIG_FILE))
+}
 
-    serde_json::from_str::<Config>(&text).map_err(|e| format!("JSON パース失敗: {}", e))
+/// Load the JSON configuration file
+pub fn load_config() -> Result<Config, String> {
+    let path = config_path();
+    let text =
+        fs::read_to_string(path).map_err(|e| format!("Failed to read config file: {}", e))?;
+
+    serde_json::from_str::<Config>(&text).map_err(|e| format!("Failed to parse JSON: {}", e))
+}
+
+/// Read the server IP from the configuration file
+#[allow(dead_code)]
+pub fn read_server_ip() -> Option<String> {
+    load_config().ok().map(|c| c.ip.to_string())
+}
+
+/// Read the server port from the configuration file
+#[allow(dead_code)]
+pub fn read_server_port() -> Option<u16> {
+    load_config().ok().map(|c| c.port)
 }

--- a/src/file_io.rs
+++ b/src/file_io.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use crate::path_manager::DATA_CLIENTS;
 
-// file_io.rs または別ファイルでも可
+// Can be placed in file_io.rs or another module
 mod hex_format {
     use serde::{self, Deserialize, Deserializer, Serializer};
 
@@ -44,24 +44,24 @@ pub struct ClientInfo {
     pub public_key: Vec<u8>,
 }
 
-/// クライアント情報を保存（clients.json に追記・更新）
+/// Save client information, appending or updating `clients.json`
 pub fn save_client_info(client: &ClientInfo) -> std::io::Result<()> {
-    // 親ディレクトリを作成（存在しない場合）
+    // Create parent directory if it doesn't exist
     if let Some(parent) = Path::new(DATA_CLIENTS).parent() {
         create_dir_all(parent)?;
     }
 
-    // 既存のデータを読み込む（存在しなければ空配列）
+    // Load existing data or start with an empty list
     let mut clients = load_all_clients().unwrap_or_else(|_| Vec::new());
 
-    // アドレスが一致するクライアントがいれば更新、なければ追加
+    // Update existing entry or append a new one
     if let Some(pos) = clients.iter().position(|c| c.address == client.address) {
         clients[pos] = client.clone();
     } else {
         clients.push(client.clone());
     }
 
-    // JSON にシリアライズして書き込み
+    // Serialize to JSON and write to file
     let json = serde_json::to_string_pretty(&clients)?;
     let mut file = File::create(DATA_CLIENTS)?;
     file.write_all(json.as_bytes())?;
@@ -69,7 +69,7 @@ pub fn save_client_info(client: &ClientInfo) -> std::io::Result<()> {
     Ok(())
 }
 
-/// clients.json からすべてのクライアント情報を読み込む
+/// Load all client information from `clients.json`
 pub fn load_all_clients() -> std::io::Result<Vec<ClientInfo>> {
     match File::open(DATA_CLIENTS) {
         Ok(mut file) => {
@@ -83,13 +83,13 @@ pub fn load_all_clients() -> std::io::Result<Vec<ClientInfo>> {
     }
 }
 
-/// 指定された IPv6 アドレスのクライアント情報を探す
+/// Find client information for a given IPv6 address
 pub fn find_client(address: &Ipv6Addr) -> std::io::Result<Option<ClientInfo>> {
     let clients = load_all_clients()?;
     Ok(clients.into_iter().find(|c| &c.address == address))
 }
 
-/// バイナリデータを 16進文字列に変換してファイルに保存
+/// Convert binary data to a hexadecimal string and save it to a file
 pub fn save_hex_to_file<P: AsRef<Path>>(path: P, data: &[u8]) -> std::io::Result<()> {
     if let Some(parent) = path.as_ref().parent() {
         create_dir_all(parent)?;
@@ -105,7 +105,7 @@ pub fn save_hex_to_file<P: AsRef<Path>>(path: P, data: &[u8]) -> std::io::Result
     Ok(())
 }
 
-/// 16進文字列ファイルをバイナリに変換して読み込み
+/// Read a hexadecimal string file and convert it to binary
 pub fn load_hex_from_file<P: AsRef<Path>>(path: P) -> std::io::Result<Vec<u8>> {
     let hex_string = std::fs::read_to_string(path)?;
     let bytes = (0..hex_string.len())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod aes;
+pub mod client;
+pub mod command;
+pub mod config;
+pub mod file_io;
+pub mod ipv6;
+pub mod message_io;
+pub mod packet;
+pub mod path_manager;
+pub mod server;
+pub mod tun;

--- a/src/message_io.rs
+++ b/src/message_io.rs
@@ -3,29 +3,29 @@ use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::error::Error;
 use std::io::{Read, Write};
 
-/// メッセージを送信（先頭に長さをつける）
+/// Send a message with a length prefix
 pub fn send_message<W: Write>(writer: &mut W, msg: &Message) -> Result<(), Box<dyn Error>> {
     let encoded = bincode::serialize(msg)?;
     let length = encoded.len() as u32;
 
-    // 長さを先頭に書く（BigEndianで4バイト）
+    // Write the length prefix (4 bytes, BigEndian)
     writer.write_u32::<BigEndian>(length)?;
-    // 本体を書き込む
+    // Write the payload
     writer.write_all(&encoded)?;
 
     Ok(())
 }
 
-/// メッセージを受信（先頭の長さを読み取ってから本体を読む）
+/// Receive a message by reading the length prefix and then the payload
 pub fn receive_message<R: Read>(reader: &mut R) -> Result<Message, Box<dyn Error>> {
-    // 先頭の 4 バイトでメッセージの長さを取得
+    // Read the first 4 bytes to get the message length
     let length = reader.read_u32::<BigEndian>()?;
     let mut buffer = vec![0u8; length as usize];
 
-    // 本体を長さぶんだけ正確に読み込む
+    // Read exactly `length` bytes for the payload
     reader.read_exact(&mut buffer)?;
 
-    // 復元
+    // Deserialize
     let msg: Message = bincode::deserialize(&buffer)?;
     Ok(msg)
 }


### PR DESCRIPTION
## Summary
- translate all code comments and runtime messages to English
- add configuration helpers and Japanese README for project overview
- expose modules via library for potential reuse

## Testing
- `cargo clippy -- -D warnings`
- `cargo test` *(fails: unresolved import `tempfile`; missing modules `crypto` and `pqc`)*

------
https://chatgpt.com/codex/tasks/task_e_6892a2e66e588322aa7041df06f07a35