### PR TITLE
Use poll to wait for TUN packets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ pqcrypto-kyber = "0.8.1"
 pqcrypto-traits = "0.3.5"
 crossbeam = "0.8"
 aes-gcm = "0.10.3"
+nix = { version = "0.28", features = ["poll"] }


### PR DESCRIPTION
## Summary
- wait for TUN packets using `poll` and only read when ready
- add `nix` dependency for polling and log poll timeouts

## Testing
- `cargo test` *(fails: unresolved import `tempfile` and missing modules)*
- `cargo clippy --all-targets -- -D warnings` *(fails: unresolved imports in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6892c57bb9a08322aa28678304879bba