### PR TITLE
Reduce standard output noise using logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ crossbeam = "0.8"
 aes-gcm = "0.10.3"
 nix = { version = "0.28", features = ["poll"] }
 lru = "0.12"
+log = "0.4"
+env_logger = "0.10"
 
 [target.'cfg(windows)'.dependencies]
 wintun = "0.5"

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,6 +23,8 @@ use std::os::unix::io::{AsRawFd, BorrowedFd};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use log::{error, info};
+
 fn spawn_receive_loop(
     mut stream: TcpStream,
     tx: Sender<Message>,
@@ -39,11 +41,11 @@ fn spawn_receive_loop(
                     ciphertext,
                     encrypted_payload,
                 } => {
-                    println!("🔐 Received encrypted data: {}", source);
+                    info!("🔐 Received encrypted data: {}", source);
 
                     let ss = match ciphertext {
                         Some(ct_bytes) => {
-                            println!(
+                            info!(
                                 "🧩 Ciphertext provided; decapsulating and caching shared key: {}",
                                 source
                             );
@@ -54,11 +56,11 @@ fn spawn_receive_loop(
                             ss
                         }
                         None => {
-                            println!("🔒 No ciphertext; using cached shared key: {}", source);
+                            info!("🔒 No ciphertext; using cached shared key: {}", source);
                             match shared_secrets.lock().unwrap().get(&source) {
                                 Some(cached) => *cached,
                                 None => {
-                                    eprintln!("❌ Shared key not cached: {}", source);
+                                    error!("❌ Shared key not cached: {}", source);
                                     continue;
                                 }
                             }
@@ -67,22 +69,22 @@ fn spawn_receive_loop(
 
                     let packet = match decrypt_packet(ss.as_bytes(), &encrypted_payload) {
                         Ok(p) => {
-                            println!("✅ Successfully decrypted packet: {}", source);
+                            info!("✅ Successfully decrypted packet: {}", source);
                             p
                         }
                         Err(e) => {
-                            eprintln!("❌ Failed to decrypt: {}", e);
+                            error!("❌ Failed to decrypt: {}", e);
                             continue;
                         }
                     };
 
-                    println!("🔒 Acquiring TUN write lock");
+                    info!("🔒 Acquiring TUN write lock");
                     let mut tun_guard = tun.lock().unwrap();
-                    println!("🔓 Acquired TUN lock");
+                    info!("🔓 Acquired TUN lock");
                     if let Err(e) = tun_guard.write_all(&packet) {
-                        eprintln!("❌ Failed to write to TUN: {}", e);
+                        error!("❌ Failed to write to TUN: {}", e);
                     } else {
-                        println!("📦 Wrote to TUN: {} bytes", packet.len());
+                        info!("📦 Wrote to TUN: {} bytes", packet.len());
                     }
                 }
                 Message::KeyResponse {
@@ -96,22 +98,22 @@ fn spawn_receive_loop(
                         target_address,
                         result,
                     }) {
-                        eprintln!("❌ Failed to forward message: {}", e);
+                        error!("❌ Failed to forward message: {}", e);
                     }
                 }
 
                 Message::RegisterResponse { .. } => {
                     if let Err(e) = tx.send(msg.clone()) {
-                        eprintln!("❌ Failed to forward message: {}", e);
+                        error!("❌ Failed to forward message: {}", e);
                     }
                 }
 
                 _ => {
-                    println!("📥 Irrelevant message: {:?}", msg);
+                    info!("📥 Irrelevant message: {:?}", msg);
                 }
             },
             Err(e) => {
-                eprintln!("❌ Failed to receive message: {}", e);
+                error!("❌ Failed to receive message: {}", e);
                 break;
             }
         }
@@ -153,7 +155,7 @@ fn process_tun_packets(
                                 continue;
                             }
 
-                            println!("📦 IPv6: {} → {}", parsed.src, parsed.dst);
+                            info!("📦 IPv6: {} → {}", parsed.src, parsed.dst);
 
                             let peer_pk = get_dst_public_key(&public_keys, rx, stream, parsed.dst)?;
                             let peer_pk = kyber1024::PublicKey::from_bytes(&peer_pk)
@@ -162,10 +164,10 @@ fn process_tun_packets(
                             let (shared_secret, ciphertext, first_time) = {
                                 let mut cache = shared_secrets.lock().unwrap();
                                 if let Some(ss) = cache.get(&parsed.dst) {
-                                    println!("🔒 Shared key found in cache: {}", parsed.dst);
+                                    info!("🔒 Shared key found in cache: {}", parsed.dst);
                                     (*ss, None, false)
                                 } else {
-                                    println!("🔒 Caching shared key: {}", parsed.dst);
+                                    info!("🔒 Caching shared key: {}", parsed.dst);
                                     let (ss, ct) = kyber1024::encapsulate(&peer_pk);
                                     cache.insert(parsed.dst, ss);
                                     (ss, Some(ct), true)
@@ -186,7 +188,7 @@ fn process_tun_packets(
                             )
                             .map_err(|e| format!("Failed to send: {}", e))?;
 
-                            println!(
+                            info!(
                                 "🔐 Sent encrypted_payload: {} (with ciphertext: {})",
                                 parsed.dst, first_time
                             );
@@ -221,7 +223,7 @@ fn process_tun_packets(
                 continue;
             }
 
-            println!("📦 IPv6: {} → {}", parsed.src, parsed.dst);
+            info!("📦 IPv6: {} → {}", parsed.src, parsed.dst);
 
             let peer_pk = get_dst_public_key(&public_keys, rx, stream, parsed.dst)?;
             let peer_pk = kyber1024::PublicKey::from_bytes(&peer_pk)
@@ -230,10 +232,10 @@ fn process_tun_packets(
             let (shared_secret, ciphertext, first_time) = {
                 let mut cache = shared_secrets.lock().unwrap();
                 if let Some(ss) = cache.get(&parsed.dst) {
-                    println!("🔒 Shared key found in cache: {}", parsed.dst);
+                    info!("🔒 Shared key found in cache: {}", parsed.dst);
                     (*ss, None, false)
                 } else {
-                    println!("🔒 Caching shared key: {}", parsed.dst);
+                    info!("🔒 Caching shared key: {}", parsed.dst);
                     let (ss, ct) = kyber1024::encapsulate(&peer_pk);
                     cache.insert(parsed.dst, ss);
                     (ss, Some(ct), true)
@@ -253,7 +255,7 @@ fn process_tun_packets(
             )
             .map_err(|e| format!("Failed to send: {}", e))?;
 
-            println!(
+            info!(
                 "🔐 Sent encrypted_payload: {} (with ciphertext: {})",
                 parsed.dst, first_time
             );
@@ -266,7 +268,7 @@ pub fn run_client() -> Result<(), String> {
     let addr = format!("{}:{}", config.ip, config.port);
 
     let mut stream = TcpStream::connect(addr).map_err(|e| format!("Connection failed: {}", e))?;
-    println!("✅ Connected to server");
+    info!("✅ Connected to server");
 
     let (my_pk, my_sk) = get_kyber_key();
     let shared_secrets = Arc::new(Mutex::new(HashMap::new()));
@@ -274,11 +276,11 @@ pub fn run_client() -> Result<(), String> {
 
     let public_key = my_pk.as_bytes();
     let local_ipv6 = ipv6_from_public_key(public_key);
-    println!("✅ Own IPv6 address: {}", local_ipv6);
+    info!("✅ Own IPv6 address: {}", local_ipv6);
 
     let (tun_device, tun_name) =
         create_tun(local_ipv6).map_err(|e| format!("Failed to create TUN: {}", e))?;
-    println!("✅ Created TUN device {}", tun_name);
+    info!("✅ Created TUN device {}", tun_name);
     let tun = Arc::new(Mutex::new(tun_device));
 
     let (tx, rx) = unbounded();
@@ -303,15 +305,15 @@ fn get_dst_public_key(
     stream: &mut TcpStream,
     address: Ipv6Addr,
 ) -> Result<Vec<u8>, String> {
-    println!("🔍 Entering get_dst_public_key for address: {}", address);
+    info!("🔍 Entering get_dst_public_key for address: {}", address);
 
     // Check LRU cache first
     if let Some(pk) = cache_get(cache, &address) {
-        println!("📦 Found cached public key for: {}", address);
+        info!("📦 Found cached public key for: {}", address);
         return Ok(pk);
     }
 
-    println!("📭 Sending KeyRequest to server for: {}", address);
+    info!("📭 Sending KeyRequest to server for: {}", address);
     send_message(
         stream,
         &Message::KeyRequest {
@@ -320,7 +322,7 @@ fn get_dst_public_key(
     )
     .map_err(|e| format!("Failed to send key request: {}", e))?;
 
-    println!("⏳ Waiting for KeyResponse for: {}", address);
+    info!("⏳ Waiting for KeyResponse for: {}", address);
 
     loop {
         match rx.recv_timeout(Duration::from_secs(3)) {
@@ -328,24 +330,24 @@ fn get_dst_public_key(
                 target_address,
                 result,
             }) if target_address == address => {
-                println!("📬 Received KeyResponse for: {}", address);
+                info!("📬 Received KeyResponse for: {}", address);
                 let public_key = result.map_err(|e| format!("Key error: {:?}", e))?;
                 cache_insert(cache, address, public_key.clone());
-                println!("✅ Cached public key for: {}", address);
+                info!("✅ Cached public key for: {}", address);
                 return Ok(public_key);
             }
 
             Ok(other) => {
-                println!("📥 Received unrelated message while waiting: {:?}", other);
+                info!("📥 Received unrelated message while waiting: {:?}", other);
             }
 
             Err(RecvTimeoutError::Timeout) => {
-                println!("⏰ Timeout waiting for KeyResponse: {}", address);
+                info!("⏰ Timeout waiting for KeyResponse: {}", address);
                 return Err("Timed out waiting for key response".to_string());
             }
 
             Err(e) => {
-                println!("❌ Error receiving from channel: {}", e);
+                info!("❌ Error receiving from channel: {}", e);
                 return Err(format!("Failed to receive from channel: {}", e));
             }
         }
@@ -371,13 +373,13 @@ fn register_to_server(
         match rx.recv_timeout(Duration::from_secs(3)) {
             Ok(Message::RegisterResponse { result }) => match result {
                 Ok(()) => {
-                    println!("✅ Registration successful");
+                    info!("✅ Registration successful");
                     return Ok(());
                 }
                 Err(e) => return Err(format!("Registration failed: {:?}", e)),
             },
             Ok(other) => {
-                println!("📥 Other message: {:?}", other);
+                info!("📥 Other message: {:?}", other);
             }
             Err(RecvTimeoutError::Timeout) => {
                 return Err("Timed out waiting for registration response".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,24 +10,29 @@ mod server;
 mod shared_keys;
 mod tun;
 
+use env_logger::Env;
+use log::{error, info};
+
 fn main() {
+    env_logger::Builder::from_env(Env::default().default_filter_or("error")).init();
+
     let args = std::env::args().collect::<Vec<_>>();
     let first_arg = args.get(1).map(|s| s.as_str()).unwrap_or("");
     match first_arg {
         "client" => {
-            println!("Running as client...");
+            info!("Running as client...");
             if let Err(e) = client::run_client() {
-                eprintln!("Client error: {}", e);
+                error!("Client error: {}", e);
             }
         }
         "server" => {
-            println!("Running as server...");
+            info!("Running as server...");
             if let Err(e) = server::run_server() {
-                eprintln!("Server error: {}", e);
+                error!("Server error: {}", e);
             }
         }
         _ => {
-            println!("Usage: {} [client|server]", args[0]);
+            error!("Usage: {} [client|server]", args[0]);
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
## Summary
- replace println!/eprintln! debug output with log-based info!/error! macros
- initialize env_logger in main with default error level for minimal stdout
- add log and env_logger dependencies

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689374399d048322975c096b859acb86