### PR TITLE
Use random nonce for AES-256-GCM packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Settings are read from `nuntium.conf`:
 
 ## Transport Encryption
 
-After exchanging keys, clients encrypt IPv6 payloads with **AES-256-GCM**. The current implementation uses a fixed 12-byte nonce, which is sufficient for initial experimentation but **must** be replaced with unique nonces for any production use to maintain confidentiality.
+After exchanging keys, clients encrypt IPv6 payloads with **AES-256-GCM**. Each packet uses a randomly generated 12-byte nonce, which is prepended to the ciphertext to ensure confidentiality.
 
 ## Disclaimer
 

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -1,23 +1,42 @@
-use aes_gcm::aead::Aead; // For runtime use
-use aes_gcm::KeyInit;
-use aes_gcm::{Aes256Gcm, Key, Nonce}; // Cipher implementation and helper types
+use aes_gcm::aead::{Aead, Error, KeyInit, OsRng}; // Runtime traits and helpers
+use aes_gcm::{AeadCore, Aes256Gcm, Key, Nonce}; // Cipher implementation and helper types
 
-pub fn encrypt_packet(key: &[u8], plaintext: &[u8]) -> Vec<u8> {
-    let key = aes_gcm::Key::<Aes256Gcm>::from_slice(&key[..32]);
+/// Encrypt a packet using AES-256-GCM.
+///
+/// A random nonce is generated for every packet and prepended to the
+/// resulting ciphertext. The provided `key` must be at least 32 bytes.
+pub fn encrypt_packet(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, Error> {
+    if key.len() < 32 {
+        return Err(Error);
+    }
 
+    let key = Key::<Aes256Gcm>::from_slice(&key[..32]);
     let cipher = Aes256Gcm::new(key);
 
-    let nonce = Nonce::from_slice(&[0u8; 12]); // Using a fixed nonce is insecure but fine for initial testing
-    cipher.encrypt(nonce, plaintext).expect("encryption failed")
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+    let mut ciphertext = cipher.encrypt(&nonce, plaintext)?;
+
+    let mut result = nonce.to_vec();
+    result.append(&mut ciphertext);
+    Ok(result)
 }
 
-pub fn decrypt_packet(key: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, String> {
-    let key = Key::<aes_gcm::aes::Aes256>::from_slice(&key[..32]);
+/// Decrypt a packet using AES-256-GCM.
+///
+/// Expects the nonce to be prepended to the ciphertext. The provided
+/// `key` must be at least 32 bytes long.
+pub fn decrypt_packet(key: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, Error> {
+    if key.len() < 32 {
+        return Err(Error);
+    }
+    if ciphertext.len() < 12 {
+        return Err(Error);
+    }
 
+    let key = Key::<Aes256Gcm>::from_slice(&key[..32]);
     let cipher = Aes256Gcm::new(key);
 
-    let nonce = Nonce::from_slice(&[0u8; 12]);
-    cipher
-        .decrypt(nonce, ciphertext)
-        .map_err(|e| format!("decryption failed: {:?}", e))
+    let (nonce_bytes, ct) = ciphertext.split_at(12);
+    let nonce = Nonce::from_slice(nonce_bytes);
+    cipher.decrypt(nonce, ct)
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -73,7 +73,7 @@ fn spawn_receive_loop(
                             p
                         }
                         Err(e) => {
-                            error!("❌ Failed to decrypt: {}", e);
+                            error!("❌ Failed to decrypt: {:?}", e);
                             continue;
                         }
                     };
@@ -175,7 +175,8 @@ fn process_tun_packets(
                             };
 
                             let encrypted_payload =
-                                encrypt_packet(shared_secret.as_bytes(), &buf[..n]);
+                                encrypt_packet(shared_secret.as_bytes(), &buf[..n])
+                                    .map_err(|e| format!("encryption failed: {:?}", e))?;
 
                             send_message(
                                 stream,
@@ -242,7 +243,8 @@ fn process_tun_packets(
                 }
             };
 
-            let encrypted_payload = encrypt_packet(shared_secret.as_bytes(), &buf[..n]);
+            let encrypted_payload = encrypt_packet(shared_secret.as_bytes(), &buf[..n])
+                .map_err(|e| format!("encryption failed: {:?}", e))?;
 
             send_message(
                 stream,

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -31,7 +31,7 @@ fn kyber512_handshake_shared_secret() {
 fn aes256gcm_round_trip() {
     let key = [0u8; 32];
     let msg = b"hello";
-    let ct = encrypt_packet(&key, msg);
+    let ct = encrypt_packet(&key, msg).expect("encrypt");
     let dec = decrypt_packet(&key, &ct).expect("decrypt");
     assert_eq!(dec, msg);
 }


### PR DESCRIPTION
## Summary
- generate random nonce per packet and prepend it to ciphertext
- validate key length and return Result from AES helpers
- handle encryption/decryption errors and update docs/tests

## Testing
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689376f7a754832297e377af9acd491e