### PR TITLE
feat: support Windows paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tun = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.3"
@@ -14,10 +13,13 @@ pqcrypto-kyber = "0.8.1"
 pqcrypto-traits = "0.3.5"
 crossbeam = "0.8"
 aes-gcm = "0.10.3"
-nix = { version = "0.28", features = ["poll"] }
 lru = "0.12"
 log = "0.4"
 env_logger = "0.10"
+
+[target.'cfg(unix)'.dependencies]
+tun = "0.5"
+nix = { version = "0.28", features = ["poll"] }
 
 [target.'cfg(windows)'.dependencies]
 wintun = "0.5"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cargo run -- client
 
 ## Configuration
 
-Settings are read from `nuntium.conf`:
+Settings are read from `nuntium.conf`. On Linux, the default location is `/etc/nuntium/nuntium.conf`; on Windows it is `C:\ProgramData\nuntium\nuntium.conf`:
 
 ```json
 {

--- a/SPEC.md
+++ b/SPEC.md
@@ -51,5 +51,5 @@ Messages are serialized with bincode and preceded by a 4‑byte big‑endian len
 - Clients create a TUN device with MTU 1500 and assign their derived IPv6 address using `ip -6 addr add {addr}/7 dev {name}`.
 
 ## Storage Paths
-Public and secret Kyber keys are stored under `/var/lib/nuntium/` and the configuration file defaults to `/etc/nuntium/nuntium.conf`.
+On Linux, public and secret Kyber keys are stored under `/var/lib/nuntium/` and the configuration file defaults to `/etc/nuntium/nuntium.conf`. On Windows, the keys and configuration file reside under `C:\\ProgramData\\nuntium\\`.
 

--- a/src/path_manager.rs
+++ b/src/path_manager.rs
@@ -1,3 +1,13 @@
-pub static DATA_PUBLIC_KEY: &str = "/var/lib/nuntium/kyber1024_public.hex";
-pub static DATA_SECRET_KEY: &str = "/var/lib/nuntium/kyber1024_secret.hex";
-pub static CONFIG_FILE: &str = "/etc/nuntium/nuntium.conf";
+#[cfg(target_os = "linux")]
+pub const DATA_PUBLIC_KEY: &str = "/var/lib/nuntium/kyber1024_public.hex";
+#[cfg(target_os = "linux")]
+pub const DATA_SECRET_KEY: &str = "/var/lib/nuntium/kyber1024_secret.hex";
+#[cfg(target_os = "linux")]
+pub const CONFIG_FILE: &str = "/etc/nuntium/nuntium.conf";
+
+#[cfg(target_os = "windows")]
+pub const DATA_PUBLIC_KEY: &str = "C:\\ProgramData\\nuntium\\kyber1024_public.hex";
+#[cfg(target_os = "windows")]
+pub const DATA_SECRET_KEY: &str = "C:\\ProgramData\\nuntium\\kyber1024_secret.hex";
+#[cfg(target_os = "windows")]
+pub const CONFIG_FILE: &str = "C:\\ProgramData\\nuntium\\nuntium.conf";

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -105,8 +105,7 @@ pub fn create_tun(ipv6_addr: Ipv6Addr) -> io::Result<(TunDevice, String)> {
         .set_mtu(MTU)
         .map_err(|e| Error::other(format!("Failed to set MTU: {}", e)))?;
 
-    let mask = wintun::util::ipv6_netmask_for_prefix(7)
-        .map_err(|e| Error::other(format!("Failed to derive netmask: {}", e)))?;
+    let mask = Ipv6Addr::from(!((1u128 << (128 - 7)) - 1));
     adapter
         .set_network_addresses_tuple(IpAddr::V6(ipv6_addr), IpAddr::V6(mask), None)
         .map_err(|e| Error::other(format!("Failed to set address: {}", e)))?;


### PR DESCRIPTION
## Summary
- add OS-specific paths for key storage and config using Windows defaults
- document Windows locations in README and spec
- make Windows build work by computing IPv6 netmask locally and scoping tun/nix deps to Unix

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo check --target x86_64-pc-windows-gnu`


------
https://chatgpt.com/codex/tasks/task_e_68944f9713d48322b577fa73a82a5008