### PR TITLE
Add macOS support for TUN device and path manager

### DIFF
--- a/src/path_manager.rs
+++ b/src/path_manager.rs
@@ -1,17 +1,26 @@
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 pub static DATA_PUBLIC_KEY: &str = "/var/lib/nuntium/kyber1024_public.hex";
+
+#[cfg(target_os = "macos")]
+pub static DATA_PUBLIC_KEY: &str = "/usr/local/var/nuntium/kyber1024_public.hex";
 
 #[cfg(windows)]
 pub static DATA_PUBLIC_KEY: &str = r"C:\ProgramData\nuntium\kyber1024_public.hex";
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 pub static DATA_SECRET_KEY: &str = "/var/lib/nuntium/kyber1024_secret.hex";
+
+#[cfg(target_os = "macos")]
+pub static DATA_SECRET_KEY: &str = "/usr/local/var/nuntium/kyber1024_secret.hex";
 
 #[cfg(windows)]
 pub static DATA_SECRET_KEY: &str = r"C:\ProgramData\nuntium\kyber1024_secret.hex";
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 pub static CONFIG_FILE: &str = "/etc/nuntium/nuntium.conf";
+
+#[cfg(target_os = "macos")]
+pub static CONFIG_FILE: &str = "/usr/local/etc/nuntium/nuntium.conf";
 
 #[cfg(windows)]
 pub static CONFIG_FILE: &str = r"C:\ProgramData\nuntium\nuntium.conf";


### PR DESCRIPTION
## Summary
- add macOS support to the TUN abstraction using `ifconfig`
- define macOS-specific configuration and key paths

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68946fd83258832292a20afb73b71b30