### PR TITLE
Remove direct cpufeatures usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ pqcrypto-traits = "0.3.5"
 crossbeam = "0.8"
 aes = { version = "0.8" }
 aes-gcm = { version = "0.10.3", features = ["aes"] }
-cpufeatures = "0.2"
 lru = "0.12"
 log = "0.4"
 env_logger = "0.10"

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -1,10 +1,5 @@
 use aes_gcm::aead::{AeadInPlace, Error, KeyInit, OsRng}; // Runtime traits and helpers
 use aes_gcm::{AeadCore, Aes256Gcm, Key, Nonce}; // Cipher implementation and helper types
-use cpufeatures::new; // For runtime CPU feature detection
-
-// Detect availability of AES instructions at runtime. The `aes-gcm` crate will
-// transparently use hardware acceleration when this feature is present.
-new!(aes_intrinsics, "aes");
 
 /// Encrypt a packet using AES-256-GCM.
 ///
@@ -15,12 +10,8 @@ pub fn encrypt_packet(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, Error> {
         return Err(Error);
     }
 
-    // Construct cipher once per call. The `aes-gcm` crate internally uses
-    // `cpufeatures` to take advantage of AES-NI or similar SIMD extensions at
-    // runtime, so simply constructing the cipher here will leverage hardware
-    // acceleration when available. We assert here so that in debug builds we
-    // notice when the binary is running without AES acceleration.
-    debug_assert!(aes_intrinsics::get(), "CPU lacks AES acceleration");
+    // Construct cipher once per call. The `aes-gcm` crate automatically detects
+    // and uses hardware acceleration when available.
     let key = Key::<Aes256Gcm>::from_slice(&key[..32]);
     let cipher = Aes256Gcm::new(key);
 


### PR DESCRIPTION
## Summary
- drop cpufeatures dependency and related runtime checks

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68947c2ee0a88322b80f240c2037e521