### PR TITLE
Log successful client registration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use env_logger::Env;
 use log::{error, info};
 
 fn main() {
-    env_logger::Builder::from_env(Env::default().default_filter_or("error")).init();
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
     // Avoid collecting all CLI arguments; only fetch the first argument if present.
     let first_arg = std::env::args().nth(1).unwrap_or_default();

--- a/src/server.rs
+++ b/src/server.rs
@@ -115,6 +115,10 @@ pub fn run_server() -> std::io::Result<()> {
 
                                     match register_client(address, public_key.clone(), &registry) {
                                         Ok(_) => {
+                                            info!(
+                                                "✅ Client registration successful: {:?}",
+                                                address
+                                            );
                                             let mut online = online_clients.lock().unwrap();
                                             if let Ok(clone) = stream.try_clone() {
                                                 online.insert(address, Arc::new(Mutex::new(clone)));


### PR DESCRIPTION
## Summary
- log a message when the server completes client registration
- default logging to info so registration logs appear without extra configuration

## Testing
- `cargo fmt`
- `cargo clippy`
- `cargo test -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_68982fc4b46c8322a2fef739d2d5a421