### PR TITLE
Add parallel crypto pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ nix = { version = "0.28", features = ["poll"] }
 lru = "0.12"
 log = "0.4"
 env_logger = "0.10"
+num_cpus = "1.16"
 
 [target.'cfg(windows)'.dependencies]
 wintun = "0.5"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
-use crate::aes::{decrypt_packet, encrypt_packet};
 use crate::command::Message;
 use crate::config::load_config;
+use crate::crypto_pool::{CryptoJob, CryptoPool};
 use crate::ipv6::{get_kyber_key, ipv6_from_public_key};
 use crate::message_io::{receive_message, send_message};
 use crate::packet::parse_ipv6_packet;
@@ -13,10 +13,10 @@ use crate::tun_writer::TunWriter;
 use pqcrypto_kyber::kyber1024;
 use pqcrypto_traits::kem::{Ciphertext as _, PublicKey as _, SharedSecret as _};
 
-use crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender};
+use crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender, TryRecvError};
 #[cfg(unix)]
 use nix::poll::{poll, PollFd, PollFlags};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::Read;
 use std::net::{Ipv6Addr, TcpStream, UdpSocket};
 #[cfg(unix)]
@@ -35,52 +35,34 @@ fn spawn_receive_loop(
     public_keys: SharedKeysCache,
     shared_secrets: Arc<Mutex<HashMap<Ipv6Addr, kyber1024::SharedSecret>>>,
     my_secret_key: kyber1024::SecretKey,
+    crypto: CryptoPool,
 ) {
-    std::thread::spawn(move || loop {
-        match receive_message(&mut stream) {
-            Ok(msg) => match msg {
-                Message::ReceiveEncryptedData {
-                    source,
-                    ciphertext,
-                    encrypted_payload,
-                } => {
-                    info!("🔐 Received encrypted data: {}", source);
+    std::thread::spawn(move || {
+        let (resp_tx, resp_rx) = unbounded();
+        let mut next_id = 0u64;
+        let mut next_to_tun = 0u64;
+        let mut inflight = 0usize;
+        let mut buffer = BTreeMap::<u64, Option<Vec<u8>>>::new();
+        const MAX_INFLIGHT: usize = 256;
 
-                    let ss = match ciphertext {
-                        Some(ct_bytes) => {
-                            info!(
-                                "🧩 Ciphertext provided; decapsulating and caching shared key: {}",
-                                source
-                            );
-                            let ct = kyber1024::Ciphertext::from_bytes(&ct_bytes)
-                                .expect("Invalid ciphertext");
-                            let ss = kyber1024::decapsulate(&ct, &my_secret_key);
-                            shared_secrets.lock().unwrap().insert(source, ss);
-                            ss
-                        }
-                        None => {
-                            info!("🔒 No ciphertext; using cached shared key: {}", source);
-                            match shared_secrets.lock().unwrap().get(&source) {
-                                Some(cached) => *cached,
-                                None => {
-                                    error!("❌ Shared key not cached: {}", source);
-                                    continue;
-                                }
-                            }
-                        }
-                    };
-
-                    let packet = match decrypt_packet(ss.as_bytes(), &encrypted_payload) {
-                        Ok(p) => {
-                            info!("✅ Successfully decrypted packet: {}", source);
-                            p
-                        }
-                        Err(e) => {
-                            error!("❌ Failed to decrypt: {:?}", e);
-                            continue;
-                        }
-                    };
-
+        fn handle_resp(
+            resp: (u64, Result<Vec<u8>, aes_gcm::aead::Error>),
+            buffer: &mut BTreeMap<u64, Option<Vec<u8>>>,
+            next: &mut u64,
+            tun: &TunWriter,
+        ) {
+            let (id, res) = resp;
+            match res {
+                Ok(pkt) => {
+                    buffer.insert(id, Some(pkt));
+                }
+                Err(e) => {
+                    error!("❌ Failed to decrypt: {:?}", e);
+                    buffer.insert(id, None);
+                }
+            }
+            while let Some(opt) = buffer.remove(next) {
+                if let Some(packet) = opt {
                     let len = packet.len();
                     if let Err(e) = tun.send(packet) {
                         error!("❌ Failed to send to TUN: {}", e);
@@ -88,34 +70,108 @@ fn spawn_receive_loop(
                         info!("📦 Wrote to TUN: {} bytes", len);
                     }
                 }
-                Message::KeyResponse {
-                    target_address,
-                    result,
-                } => {
-                    if let Ok(ref pk) = result {
-                        cache_insert(&public_keys, target_address, pk.clone());
+                *next += 1;
+            }
+        }
+
+        loop {
+            while inflight >= MAX_INFLIGHT {
+                match resp_rx.recv() {
+                    Ok(r) => {
+                        inflight -= 1;
+                        handle_resp(r, &mut buffer, &mut next_to_tun, &tun);
                     }
-                    if let Err(e) = tx.send(Message::KeyResponse {
+                    Err(_) => return,
+                }
+            }
+
+            match receive_message(&mut stream) {
+                Ok(msg) => match msg {
+                    Message::ReceiveEncryptedData {
+                        source,
+                        ciphertext,
+                        encrypted_payload,
+                    } => {
+                        info!("🔐 Received encrypted data: {}", source);
+
+                        let ss = match ciphertext {
+                            Some(ct_bytes) => {
+                                info!(
+                                    "🧩 Ciphertext provided; decapsulating and caching shared key: {}",
+                                    source
+                                );
+                                let ct = kyber1024::Ciphertext::from_bytes(&ct_bytes)
+                                    .expect("Invalid ciphertext");
+                                let ss = kyber1024::decapsulate(&ct, &my_secret_key);
+                                shared_secrets.lock().unwrap().insert(source, ss);
+                                ss
+                            }
+                            None => {
+                                info!("🔒 No ciphertext; using cached shared key: {}", source);
+                                match shared_secrets.lock().unwrap().get(&source) {
+                                    Some(cached) => *cached,
+                                    None => {
+                                        error!("❌ Shared key not cached: {}", source);
+                                        continue;
+                                    }
+                                }
+                            }
+                        };
+
+                        let id = next_id;
+                        next_id += 1;
+                        inflight += 1;
+
+                        if let Err(e) = crypto.submit(CryptoJob::Decrypt {
+                            packet_id: id,
+                            key: ss.as_bytes().to_vec(),
+                            data: encrypted_payload,
+                            resp: resp_tx.clone(),
+                        }) {
+                            error!("❌ Failed to submit decrypt job: {}", e);
+                            inflight -= 1;
+                        }
+                    }
+                    Message::KeyResponse {
                         target_address,
                         result,
-                    }) {
-                        error!("❌ Failed to forward message: {}", e);
+                    } => {
+                        if let Ok(ref pk) = result {
+                            cache_insert(&public_keys, target_address, pk.clone());
+                        }
+                        if let Err(e) = tx.send(Message::KeyResponse {
+                            target_address,
+                            result,
+                        }) {
+                            error!("❌ Failed to forward message: {}", e);
+                        }
                     }
-                }
 
-                Message::RegisterResponse { .. } => {
-                    if let Err(e) = tx.send(msg.clone()) {
-                        error!("❌ Failed to forward message: {}", e);
+                    Message::RegisterResponse { .. } => {
+                        if let Err(e) = tx.send(msg.clone()) {
+                            error!("❌ Failed to forward message: {}", e);
+                        }
                     }
-                }
 
-                _ => {
-                    info!("📥 Irrelevant message: {:?}", msg);
+                    _ => {
+                        info!("📥 Irrelevant message: {:?}", msg);
+                    }
+                },
+                Err(e) => {
+                    error!("❌ Failed to receive message: {}", e);
+                    break;
                 }
-            },
-            Err(e) => {
-                error!("❌ Failed to receive message: {}", e);
-                break;
+            }
+
+            loop {
+                match resp_rx.try_recv() {
+                    Ok(r) => {
+                        inflight -= 1;
+                        handle_resp(r, &mut buffer, &mut next_to_tun, &tun);
+                    }
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => return,
+                }
             }
         }
     });
@@ -126,66 +182,122 @@ fn spawn_udp_receive_loop(
     tun: TunWriter,
     shared_secrets: Arc<Mutex<HashMap<Ipv6Addr, kyber1024::SharedSecret>>>,
     my_secret_key: kyber1024::SecretKey,
+    crypto: CryptoPool,
 ) {
-    std::thread::spawn(move || loop {
-        let mut buf = [0u8; 65535];
-        match socket.recv(&mut buf) {
-            Ok(size) => {
-                if let Ok(Message::ReceiveEncryptedData {
-                    source,
-                    ciphertext,
-                    encrypted_payload,
-                }) = crate::message_io::deserialize_message(&buf[..size])
-                {
-                    info!("🔐 Received encrypted data via UDP: {}", source);
-                    let ss = match ciphertext {
-                        Some(ct_bytes) => {
-                            info!(
-                                "🧩 Ciphertext provided; decapsulating and caching shared key: {}",
-                                source
-                            );
-                            let ct = kyber1024::Ciphertext::from_bytes(&ct_bytes)
-                                .expect("Invalid ciphertext");
-                            let ss = kyber1024::decapsulate(&ct, &my_secret_key);
-                            shared_secrets.lock().unwrap().insert(source, ss);
-                            ss
-                        }
-                        None => {
-                            info!("🔒 No ciphertext; using cached shared key: {}", source);
-                            match shared_secrets.lock().unwrap().get(&source) {
-                                Some(cached) => *cached,
-                                None => {
-                                    error!("❌ Shared key not cached: {}", source);
-                                    continue;
-                                }
-                            }
-                        }
-                    };
+    std::thread::spawn(move || {
+        let (resp_tx, resp_rx) = unbounded();
+        let mut next_id = 0u64;
+        let mut next_to_tun = 0u64;
+        let mut inflight = 0usize;
+        let mut buffer = BTreeMap::<u64, Option<Vec<u8>>>::new();
+        const MAX_INFLIGHT: usize = 256;
 
-                    let packet = match decrypt_packet(ss.as_bytes(), &encrypted_payload) {
-                        Ok(p) => {
-                            info!("✅ Successfully decrypted packet: {}", source);
-                            p
-                        }
-                        Err(e) => {
-                            error!("❌ Failed to decrypt: {:?}", e);
-                            continue;
-                        }
-                    };
-
+        fn handle_resp(
+            resp: (u64, Result<Vec<u8>, aes_gcm::aead::Error>),
+            buffer: &mut BTreeMap<u64, Option<Vec<u8>>>,
+            next: &mut u64,
+            tun: &TunWriter,
+        ) {
+            let (id, res) = resp;
+            match res {
+                Ok(pkt) => {
+                    buffer.insert(id, Some(pkt));
+                }
+                Err(e) => {
+                    error!("❌ Failed to decrypt: {:?}", e);
+                    buffer.insert(id, None);
+                }
+            }
+            while let Some(opt) = buffer.remove(next) {
+                if let Some(packet) = opt {
                     let len = packet.len();
                     if let Err(e) = tun.send(packet) {
                         error!("❌ Failed to send to TUN: {}", e);
                     } else {
                         info!("📦 Wrote to TUN: {} bytes", len);
                     }
-                } else {
-                    error!("❌ Failed to deserialize UDP message");
+                }
+                *next += 1;
+            }
+        }
+
+        let mut buf = [0u8; 65535];
+        loop {
+            while inflight >= MAX_INFLIGHT {
+                match resp_rx.recv() {
+                    Ok(r) => {
+                        inflight -= 1;
+                        handle_resp(r, &mut buffer, &mut next_to_tun, &tun);
+                    }
+                    Err(_) => return,
                 }
             }
-            Err(e) => {
-                error!("❌ Failed to receive UDP message: {}", e);
-                break;
+
+            match socket.recv(&mut buf) {
+                Ok(size) => {
+                    if let Ok(Message::ReceiveEncryptedData {
+                        source,
+                        ciphertext,
+                        encrypted_payload,
+                    }) = crate::message_io::deserialize_message(&buf[..size])
+                    {
+                        info!("🔐 Received encrypted data via UDP: {}", source);
+                        let ss = match ciphertext {
+                            Some(ct_bytes) => {
+                                info!(
+                                    "🧩 Ciphertext provided; decapsulating and caching shared key: {}",
+                                    source
+                                );
+                                let ct = kyber1024::Ciphertext::from_bytes(&ct_bytes)
+                                    .expect("Invalid ciphertext");
+                                let ss = kyber1024::decapsulate(&ct, &my_secret_key);
+                                shared_secrets.lock().unwrap().insert(source, ss);
+                                ss
+                            }
+                            None => {
+                                info!("🔒 No ciphertext; using cached shared key: {}", source);
+                                match shared_secrets.lock().unwrap().get(&source) {
+                                    Some(cached) => *cached,
+                                    None => {
+                                        error!("❌ Shared key not cached: {}", source);
+                                        continue;
+                                    }
+                                }
+                            }
+                        };
+
+                        let id = next_id;
+                        next_id += 1;
+                        inflight += 1;
+
+                        if let Err(e) = crypto.submit(CryptoJob::Decrypt {
+                            packet_id: id,
+                            key: ss.as_bytes().to_vec(),
+                            data: encrypted_payload,
+                            resp: resp_tx.clone(),
+                        }) {
+                            error!("❌ Failed to submit decrypt job: {}", e);
+                            inflight -= 1;
+                        }
+                    } else {
+                        error!("❌ Failed to deserialize UDP message");
+                    }
+                }
+                Err(e) => {
+                    error!("❌ Failed to receive UDP message: {}", e);
+                    break;
+                }
+            }
+
+            loop {
+                match resp_rx.try_recv() {
+                    Ok(r) => {
+                        inflight -= 1;
+                        handle_resp(r, &mut buffer, &mut next_to_tun, &tun);
+                    }
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => return,
+                }
             }
         }
     });
@@ -199,18 +311,85 @@ fn process_tun_packets(
     public_keys: SharedKeysCache,
     shared_secrets: Arc<Mutex<HashMap<Ipv6Addr, kyber1024::SharedSecret>>>,
     mut tun: TunDevice,
+    crypto: CryptoPool,
 ) -> Result<(), String> {
     let mut buf = [0u8; MTU];
+    let (resp_tx, resp_rx) = unbounded();
+    let mut next_id = 0u64;
+    let mut next_to_send = 0u64;
+    let mut inflight = 0usize;
+    let mut meta = BTreeMap::<u64, (Ipv6Addr, Ipv6Addr, Option<Vec<u8>>, bool)>::new();
+    let mut ready = BTreeMap::<u64, Option<(Message, bool)>>::new();
+    const MAX_INFLIGHT: usize = 256;
+
+    #[allow(clippy::type_complexity)]
+    fn handle_resp(
+        resp: (u64, Result<Vec<u8>, aes_gcm::aead::Error>),
+        meta: &mut BTreeMap<u64, (Ipv6Addr, Ipv6Addr, Option<Vec<u8>>, bool)>,
+        ready: &mut BTreeMap<u64, Option<(Message, bool)>>,
+        next: &mut u64,
+        udp: &UdpSocket,
+    ) -> Result<(), String> {
+        let (id, res) = resp;
+        match res {
+            Ok(payload) => {
+                if let Some((src, dst, ct, first)) = meta.remove(&id) {
+                    let msg = Message::SendEncryptedData {
+                        source: src,
+                        destination: dst,
+                        ciphertext: ct.clone(),
+                        encrypted_payload: payload,
+                    };
+                    ready.insert(id, Some((msg, first)));
+                } else {
+                    ready.insert(id, None);
+                }
+            }
+            Err(e) => {
+                error!("❌ Failed to encrypt: {:?}", e);
+                meta.remove(&id);
+                ready.insert(id, None);
+            }
+        }
+
+        while let Some(opt) = ready.remove(next) {
+            if let Some((msg, first)) = opt {
+                let dst = match &msg {
+                    Message::SendEncryptedData { destination, .. } => *destination,
+                    _ => Ipv6Addr::UNSPECIFIED,
+                };
+                let bytes = crate::message_io::serialize_message(&msg)
+                    .map_err(|e| format!("serialize failed: {}", e))?;
+                udp.send(&bytes)
+                    .map_err(|e| format!("Failed to send UDP: {}", e))?;
+                info!(
+                    "🔐 Sent encrypted_payload: {} (with ciphertext: {})",
+                    dst, first
+                );
+            }
+            *next += 1;
+        }
+        Ok(())
+    }
+
     loop {
+        while inflight >= MAX_INFLIGHT {
+            match resp_rx.recv() {
+                Ok(r) => {
+                    inflight -= 1;
+                    handle_resp(r, &mut meta, &mut ready, &mut next_to_send, udp)?;
+                }
+                Err(_) => return Err("crypto response channel closed".into()),
+            }
+        }
+
         let fd = tun.as_raw_fd();
         let mut fds = [PollFd::new(
             unsafe { BorrowedFd::borrow_raw(fd) },
             PollFlags::POLLIN,
         )];
         match poll(&mut fds, 1000u16) {
-            Ok(0) => {
-                continue;
-            }
+            Ok(0) => {}
             Ok(_) => {
                 if let Some(revents) = fds[0].revents() {
                     if revents.contains(PollFlags::POLLIN) {
@@ -241,31 +420,45 @@ fn process_tun_packets(
                                 }
                             };
 
-                            let encrypted_payload =
-                                encrypt_packet(shared_secret.as_bytes(), &buf[..n])
-                                    .map_err(|e| format!("encryption failed: {:?}", e))?;
-
-                            let msg = Message::SendEncryptedData {
-                                source: parsed.src,
-                                destination: parsed.dst,
-                                ciphertext: ciphertext.map(|ct| ct.as_bytes().to_vec()),
-                                encrypted_payload,
-                            };
-                            let bytes = crate::message_io::serialize_message(&msg)
-                                .map_err(|e| format!("serialize failed: {}", e))?;
-                            udp.send(&bytes)
-                                .map_err(|e| format!("Failed to send UDP: {}", e))?;
-
-                            info!(
-                                "🔐 Sent encrypted_payload: {} (with ciphertext: {})",
-                                parsed.dst, first_time
+                            let id = next_id;
+                            next_id += 1;
+                            inflight += 1;
+                            meta.insert(
+                                id,
+                                (
+                                    parsed.src,
+                                    parsed.dst,
+                                    ciphertext.map(|c| c.as_bytes().to_vec()),
+                                    first_time,
+                                ),
                             );
+
+                            if let Err(e) = crypto.submit(CryptoJob::Encrypt {
+                                packet_id: id,
+                                key: shared_secret.as_bytes().to_vec(),
+                                data: buf[..n].to_vec(),
+                                resp: resp_tx.clone(),
+                            }) {
+                                meta.remove(&id);
+                                return Err(format!("failed to submit encrypt job: {}", e));
+                            }
                         }
                     }
                 }
             }
-            Err(e) => {
-                return Err(format!("poll failed: {}", e));
+            Err(e) => return Err(format!("poll failed: {}", e)),
+        }
+
+        loop {
+            match resp_rx.try_recv() {
+                Ok(r) => {
+                    inflight -= 1;
+                    handle_resp(r, &mut meta, &mut ready, &mut next_to_send, udp)?;
+                }
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    return Err("crypto response channel closed".into());
+                }
             }
         }
     }
@@ -279,9 +472,78 @@ fn process_tun_packets(
     public_keys: SharedKeysCache,
     shared_secrets: Arc<Mutex<HashMap<Ipv6Addr, kyber1024::SharedSecret>>>,
     mut tun: TunDevice,
+    crypto: CryptoPool,
 ) -> Result<(), String> {
     let mut buf = [0u8; MTU];
+    let (resp_tx, resp_rx) = unbounded();
+    let mut next_id = 0u64;
+    let mut next_to_send = 0u64;
+    let mut inflight = 0usize;
+    let mut meta = BTreeMap::<u64, (Ipv6Addr, Ipv6Addr, Option<Vec<u8>>, bool)>::new();
+    let mut ready = BTreeMap::<u64, Option<(Message, bool)>>::new();
+    const MAX_INFLIGHT: usize = 256;
+
+    #[allow(clippy::type_complexity)]
+    fn handle_resp(
+        resp: (u64, Result<Vec<u8>, aes_gcm::aead::Error>),
+        meta: &mut BTreeMap<u64, (Ipv6Addr, Ipv6Addr, Option<Vec<u8>>, bool)>,
+        ready: &mut BTreeMap<u64, Option<(Message, bool)>>,
+        next: &mut u64,
+        udp: &UdpSocket,
+    ) -> Result<(), String> {
+        let (id, res) = resp;
+        match res {
+            Ok(payload) => {
+                if let Some((src, dst, ct, first)) = meta.remove(&id) {
+                    let msg = Message::SendEncryptedData {
+                        source: src,
+                        destination: dst,
+                        ciphertext: ct.clone(),
+                        encrypted_payload: payload,
+                    };
+                    ready.insert(id, Some((msg, first)));
+                } else {
+                    ready.insert(id, None);
+                }
+            }
+            Err(e) => {
+                error!("❌ Failed to encrypt: {:?}", e);
+                meta.remove(&id);
+                ready.insert(id, None);
+            }
+        }
+
+        while let Some(opt) = ready.remove(next) {
+            if let Some((msg, first)) = opt {
+                let dst = match &msg {
+                    Message::SendEncryptedData { destination, .. } => *destination,
+                    _ => Ipv6Addr::UNSPECIFIED,
+                };
+                let bytes = crate::message_io::serialize_message(&msg)
+                    .map_err(|e| format!("serialize failed: {}", e))?;
+                udp.send(&bytes)
+                    .map_err(|e| format!("Failed to send UDP: {}", e))?;
+                info!(
+                    "🔐 Sent encrypted_payload: {} (with ciphertext: {})",
+                    dst, first
+                );
+            }
+            *next += 1;
+        }
+        Ok(())
+    }
+
     loop {
+        while inflight >= MAX_INFLIGHT {
+            match resp_rx.recv() {
+                Ok(r) => {
+                    inflight -= 1;
+                    handle_resp(r, &mut meta, &mut ready, &mut next_to_send, udp)?;
+                }
+                Err(_) => return Err("crypto response channel closed".into()),
+            }
+        }
+
         let n = tun
             .read(&mut buf)
             .map_err(|e| format!("TUN read failed: {}", e))?;
@@ -309,24 +571,41 @@ fn process_tun_packets(
                 }
             };
 
-            let encrypted_payload = encrypt_packet(shared_secret.as_bytes(), &buf[..n])
-                .map_err(|e| format!("encryption failed: {:?}", e))?;
-
-            let msg = Message::SendEncryptedData {
-                source: parsed.src,
-                destination: parsed.dst,
-                ciphertext: ciphertext.map(|ct| ct.as_bytes().to_vec()),
-                encrypted_payload,
-            };
-            let bytes = crate::message_io::serialize_message(&msg)
-                .map_err(|e| format!("serialize failed: {}", e))?;
-            udp.send(&bytes)
-                .map_err(|e| format!("Failed to send UDP: {}", e))?;
-
-            info!(
-                "🔐 Sent encrypted_payload: {} (with ciphertext: {})",
-                parsed.dst, first_time
+            let id = next_id;
+            next_id += 1;
+            inflight += 1;
+            meta.insert(
+                id,
+                (
+                    parsed.src,
+                    parsed.dst,
+                    ciphertext.map(|c| c.as_bytes().to_vec()),
+                    first_time,
+                ),
             );
+
+            if let Err(e) = crypto.submit(CryptoJob::Encrypt {
+                packet_id: id,
+                key: shared_secret.as_bytes().to_vec(),
+                data: buf[..n].to_vec(),
+                resp: resp_tx.clone(),
+            }) {
+                meta.remove(&id);
+                return Err(format!("failed to submit encrypt job: {}", e));
+            }
+        }
+
+        loop {
+            match resp_rx.try_recv() {
+                Ok(r) => {
+                    inflight -= 1;
+                    handle_resp(r, &mut meta, &mut ready, &mut next_to_send, udp)?;
+                }
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    return Err("crypto response channel closed".into());
+                }
+            }
         }
     }
 }
@@ -362,6 +641,8 @@ pub fn run_client() -> Result<(), String> {
 
     let (tx, rx) = unbounded();
 
+    let crypto = CryptoPool::new();
+
     let my_sk_clone = my_sk;
     spawn_receive_loop(
         stream.try_clone().unwrap(),
@@ -370,12 +651,14 @@ pub fn run_client() -> Result<(), String> {
         public_keys.clone(),
         shared_secrets.clone(),
         my_sk_clone,
+        crypto.clone(),
     );
     spawn_udp_receive_loop(
         udp_socket.try_clone().unwrap(),
         tun_writer.clone(),
         shared_secrets.clone(),
         my_sk,
+        crypto.clone(),
     );
 
     register_to_server(&rx, &mut stream, local_ipv6, public_key)?;
@@ -387,6 +670,7 @@ pub fn run_client() -> Result<(), String> {
         public_keys,
         shared_secrets,
         tun_reader,
+        crypto,
     );
 
     tun_writer.shutdown();

--- a/src/crypto_pool.rs
+++ b/src/crypto_pool.rs
@@ -1,0 +1,73 @@
+use crate::aes::{decrypt_packet, encrypt_packet};
+use aes_gcm::aead::Error;
+use crossbeam_channel::{bounded, Receiver, Sender};
+use std::thread;
+
+pub enum CryptoJob {
+    Encrypt {
+        packet_id: u64,
+        key: Vec<u8>,
+        data: Vec<u8>,
+        resp: Sender<(u64, Result<Vec<u8>, Error>)>,
+    },
+    Decrypt {
+        packet_id: u64,
+        key: Vec<u8>,
+        data: Vec<u8>,
+        resp: Sender<(u64, Result<Vec<u8>, Error>)>,
+    },
+}
+
+#[derive(Clone)]
+pub struct CryptoPool {
+    tx: Sender<CryptoJob>,
+}
+
+impl CryptoPool {
+    pub fn new() -> Self {
+        let workers = std::env::var("NUNTIUM_CRYPTO_WORKERS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or_else(num_cpus::get)
+            .max(2);
+        let (tx, rx): (Sender<CryptoJob>, Receiver<CryptoJob>) = bounded(256);
+        for _ in 0..workers {
+            let rx = rx.clone();
+            thread::spawn(move || {
+                while let Ok(job) = rx.recv() {
+                    match job {
+                        CryptoJob::Encrypt {
+                            packet_id,
+                            key,
+                            data,
+                            resp,
+                        } => {
+                            let res = encrypt_packet(&key, &data);
+                            let _ = resp.send((packet_id, res));
+                        }
+                        CryptoJob::Decrypt {
+                            packet_id,
+                            key,
+                            data,
+                            resp,
+                        } => {
+                            let res = decrypt_packet(&key, &data);
+                            let _ = resp.send((packet_id, res));
+                        }
+                    }
+                }
+            });
+        }
+        Self { tx }
+    }
+
+    pub fn submit(&self, job: CryptoJob) -> Result<(), crossbeam_channel::SendError<CryptoJob>> {
+        self.tx.send(job)
+    }
+}
+
+impl Default for CryptoPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod aes;
 pub mod client;
 pub mod command;
 pub mod config;
+pub mod crypto_pool;
 pub mod ipv6;
 pub mod message_io;
 pub mod packet;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod aes;
 mod client;
 mod command;
 mod config;
+mod crypto_pool;
 mod ipv6;
 mod message_io;
 mod packet;


### PR DESCRIPTION
## Summary
- introduce `CryptoPool` for parallel AES-GCM encrypt/decrypt jobs with worker count via `NUNTIUM_CRYPTO_WORKERS`
- refactor client to offload packet crypto work to the pool while preserving ordering
- add `num_cpus` dependency

## Testing
- `cargo test`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_68984e78a2c483228fad31c5720fbd00